### PR TITLE
Improve the accuracy of the "runtime" parameter 

### DIFF
--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -343,12 +343,9 @@ public class PravegaPerfTest {
                 long timeSpent = System.currentTimeMillis() - loopStartTime;
                 // wait for next event
                 try {
-                    //There is no need for sleep for blocking calls.
-                    if ( !blocking ) {
-                        if ( timeSpent < 1000) {
-                            Thread.sleep(1000 - timeSpent);
-                        }
-                    }
+                     if (timeSpent < 1000) {
+                          Thread.sleep(1000 - timeSpent);
+                     }
                 } catch (InterruptedException e) {
                     // log exception
                     System.exit(1);

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -305,12 +305,14 @@ public class PravegaPerfTest {
         void runLoop(BiFunction<String, String, CompletableFuture> fn) {
 
             CompletableFuture retFuture = null;
-            for (int i = 0; i < secondsToRun; i++) {
-                int currentEventsPerSec = 0;
+            final long StartTime = System.currentTimeMillis();
+            final long Mseconds = secondsToRun*1000;
+            long DiffTime = Mseconds;
+
+            do {
 
                 long loopStartTime = System.currentTimeMillis();
-                while ( currentEventsPerSec < eventsPerSec) {
-                    currentEventsPerSec++;
+                for (int i = 0; i < eventsPerSec; i++)  {
 
                     // Construct event payload
                     String val = System.currentTimeMillis() + ", " + producerId + ", " + (int) (Math.random() * 200);
@@ -351,7 +353,10 @@ public class PravegaPerfTest {
                     // log exception
                     System.exit(1);
                 }
-            }
+                DiffTime = System.currentTimeMillis() - StartTime; 
+ 
+            } while(DiffTime < Mseconds);
+
             producer.flush();
             //producer.close();
             try {


### PR DESCRIPTION
The runtime parameters accuracy is improved by recording the time stamp before starting the loop of every thread. in case time elapsed and thread did not get the opportunity to run with in the "runtime" then at-least once execution is guaranteed.