### PR TITLE
Manual scaling, runtime, latency and segments improvements

### DIFF
--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -21,6 +21,7 @@ package com.emc.pravega.perf;
 
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
@@ -31,9 +32,8 @@ class PerfStats {
     private long windowStartTime;
     private long start;
     private long windowStart;
-    private double[] latencies;
+    private ArrayList<Double> latencies;
     private int iteration;
-    private int index;
     private long count;
     private long bytes;
     private double maxLatency;
@@ -42,22 +42,19 @@ class PerfStats {
     private long windowBytes;
     private long reportingInterval;
 
-    public PerfStats(String action, long numRecords, int reportingInterval, int messageSize) {
-        if ( numRecords != 0 ) {
-            this.action = action;
-            this.start = System.currentTimeMillis();
-            this.windowStartTime = System.currentTimeMillis();
-            this.windowStart = 0;
-            this.index = 0;
-            this.iteration = 0;
-            this.latencies = new double[(int) (numRecords / reportingInterval)];
-            this.maxLatency = 0;
-            this.totalLatency = 0;
-            this.windowCount = 0;
-            this.windowBytes = 0;
-            this.reportingInterval = reportingInterval;
-            this.messageSize = messageSize;
-        }
+    public PerfStats(String action, int reportingInterval, int messageSize) {
+           this.action = action;
+           this.start = System.currentTimeMillis();
+           this.windowStartTime = System.currentTimeMillis();
+           this.windowStart = 0;
+           this.iteration = 0;
+           this.latencies = new  ArrayList<Double>();
+           this.maxLatency = 0;
+           this.totalLatency = 0;
+           this.windowCount = 0;
+           this.windowBytes = 0;
+           this.reportingInterval = reportingInterval;
+           this.messageSize = messageSize;
     }
 
     public synchronized void record(int bytes, long startTime, long endTime) {
@@ -79,9 +76,8 @@ class PerfStats {
 
         this.bytes += this.windowBytes;
         this.totalLatency += latency; 
-        this.maxLatency = Math.max(this.maxLatency, latency);  
-        this.latencies[index] = latency;
-        this.index++;
+        this.maxLatency = Math.max(this.maxLatency, latency); 
+        this.latencies.add(latency);
         this.count++;
         
         System.out.printf("%8d records %s, %9.1f records/sec, %9.3f MB/sec, %7.4f ms avg latency.\n",
@@ -110,8 +106,8 @@ class PerfStats {
         double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);
         //double[] percs = percentiles(this.latencies, 0.5, 0.95, 0.99, 0.999);
         System.out.printf(
-                "%d records sent, %.3f records/sec, %d bytes record size, %.3f MB/sec, %.4f ms avg latency, %.4f ms max latency\n", 
-                iteration, recsPerSec,  messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency);
+                "%d records %s, %.3f records/sec, %d bytes record size, %.3f MB/sec, %.4f ms avg latency, %.4f ms max latency\n", 
+                iteration, action, recsPerSec,  messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency);
         /*  
         System.out.printf("latencies percentiles:  %.4f ms 50th, %.4f ms 95th, %.4f ms 99th, %.4f ms 99.9th.\n",
                            percs[0], percs[1], percs[2], percs[3]);

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -145,7 +145,7 @@ class PerfStats {
         return values;
     }
 
-    public CompletableFuture runAndRecordTime(Supplier<CompletableFuture> fn, long startTime, int length, Executor executor) {
+    public CompletableFuture runAndRecordTime(Supplier<CompletableFuture> fn, long startTime, int length) {
         int iter = this.iteration++;
         CompletableFuture  retVal = fn.get();
         if(retVal == null) {

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -55,7 +55,6 @@ class PerfStats {
             this.iteration = 0;
             this.sampling = (int) (numRecords / Math.min(numRecords, 500000));
             this.latencies = new long[(int) (numRecords / this.sampling)];
-            this.index = 0;
             this.maxLatency = 0;
             this.totalLatency = 0;
             this.windowCount = 0;
@@ -158,4 +157,30 @@ class PerfStats {
         return retVal;
 
     }
+
+    public CompletableFuture writeAndRecordTime(Supplier<CompletableFuture> fn, int length, boolean blocking ) {
+        CompletableFuture  retVal=null;
+        long startTime, endTime;
+        int iter = this.iteration++;
+        startTime = System.currentTimeMillis();
+        try {
+             retVal = fn.get();
+             if (blocking) {
+                  retVal.get();
+             }
+        } catch (Exception e) {
+             e.printStackTrace();
+        }
+        endTime = System.currentTimeMillis();
+        
+        if(retVal == null) {
+            record(iter, length, startTime,  endTime);
+        } else {
+            retVal = retVal.thenAccept((d) -> {
+                record(iter, length, startTime, endTime);
+            });
+        }
+        return retVal;
+    }
+
 }

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -68,7 +68,8 @@ class PerfStats {
         }
     }
 
-    public synchronized void record(int iter, int latencyMicro, int bytes, long time) {
+    public synchronized void record(int iter, int bytes, long startTime, long endTime) {
+        int latencyMicro = (int)(endTime-startTime)*1000;
         this.count++;
         this.bytes += bytes;
         this.totalLatency += latencyMicro;
@@ -81,23 +82,21 @@ class PerfStats {
             this.latencies[index] = latencyMicro;
             this.index++;
         }
-        /* maybe report the recent perf */
-        if (count - windowStart >= reportingInterval) {
-            printWindow();
+        /* did we arrived at reporting time */
+        if (endTime - windowStartTime  >= reportingInterval) {
+            printWindow(endTime);
             newWindow(count);
         }
     }
 
-    private void printWindow() {
-        long elapsed = System.currentTimeMillis() - windowStartTime;
+    private void printWindow(long endTime) {
+        long elapsed = endTime - windowStartTime;
         double recsPerSec = 1000.0 * windowCount / (double) elapsed;
         double mbPerSec = 1000.0 * this.windowBytes / (double) elapsed / (1024.0 * 1024.0);
-        System.out.printf("%d records %s, %.1f records/sec (%.5f MB/sec), %.1f ms avg latency, %.1f max latency.\n",
-                windowCount, action, recsPerSec, mbPerSec, windowTotalLatency / ((double) windowCount * 1000.0),
-                (double) windowMaxLatency / 1000.0);
-        System.out.printf(" WINDOW: %d, %d, %.1f ,%.5f MB/sec, %.1f, %.1f \n",
-                messageSize, windowCount, recsPerSec, mbPerSec, windowTotalLatency / ((double) windowCount * 1000.0),
-                (double) windowMaxLatency / 1000.0);
+        System.out.printf("%8d records %s, %9.1f records/sec, %9.3f MB/sec, %7.3f ms avg latency, %7.1f max latency.\n",
+                windowCount, action, recsPerSec, mbPerSec,  
+                (double)(windowTotalLatency / (windowCount*1000.0)),
+                (double) windowMaxLatency/1000.0);
     }
 
     private void newWindow(long currentNumber) {
@@ -118,18 +117,18 @@ class PerfStats {
         */
     }
 
-    public synchronized void printTotal() {
-        long elapsed = System.currentTimeMillis() - start;
+    public synchronized void printTotal(long endTime) {
+        long elapsed = endTime - start;
         double recsPerSec = 1000.0 * count / (double) elapsed;
         double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);
         long[] percs = percentiles(this.latencies, 0.5, 0.95, 0.99, 0.999);
         System.out.printf(
-                "%d records sent, %f records/sec (%.5f MB/sec), %.2f ms avg latency, %.2f ms max " + "latency, %.2f " +
+                "%d records sent, %f records/sec, %.5f MB/sec, %.4f ms avg latency, %.2f ms max " + "latency, %.2f " +
                         "ms 50th, %.2f ms 95th, %.2f ms 99th, %.2f ms 99.9th.\n",
                 count, recsPerSec, mbPerSec, totalLatency / ((double) count * 1000.0), (double) maxLatency / 1000.0,
                 percs[0] / 1000.0, percs[1] / 1000.0, percs[2] / 1000.0, percs[3] / 1000.0);
         System.out.printf(
-                " %s FINAL:, %d, %.5f MB/sec, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f\n", this.action,
+                "%s FINAL: %d, %.5f MB/sec, %.4f, %.2f, %.2f, %.2f, %.2f, %.2f\n", this.action,
                 messageSize, mbPerSec, totalLatency / ((double) count * 1000.0), (double) maxLatency / 1000.0,
                 percs[0] / 1000.0, percs[1] / 1000.0, percs[2] / 1000.0, percs[3] / 1000.0);
     }
@@ -148,11 +147,12 @@ class PerfStats {
     public CompletableFuture runAndRecordTime(Supplier<CompletableFuture> fn, long startTime, int length) {
         int iter = this.iteration++;
         CompletableFuture  retVal = fn.get();
+        long endTime = System.currentTimeMillis(); 
         if(retVal == null) {
-            record(iter, (int) (System.currentTimeMillis() - startTime) * 1000, length, System.nanoTime());
+            record(iter, length,startTime,  endTime);
         } else {
             retVal = retVal.thenAccept((d) -> {
-                record(iter, (int) (System.currentTimeMillis() - startTime) * 1000, length, System.nanoTime());
+                record(iter, length,startTime, endTime);
             });
         }
         return retVal;

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -127,11 +127,12 @@ class PerfStats {
 
     public CompletableFuture runAndRecordTime(Supplier<CompletableFuture> fn, long startTime, int length) {
         CompletableFuture  retVal = fn.get();
-        long endTime = System.currentTimeMillis(); 
         if(retVal == null) {
+            final long endTime = System.currentTimeMillis();
             record(length,startTime,  endTime);
         } else {
             retVal = retVal.thenAccept((d) -> {
+                final long endTime = System.currentTimeMillis();
                 record(length,startTime, endTime);
             });
         }
@@ -141,8 +142,8 @@ class PerfStats {
 
     public CompletableFuture writeAndRecordTime(Supplier<CompletableFuture> fn, int length, boolean blocking ) {
         CompletableFuture  retVal=null;
-        long startTime, endTime;
-        startTime = System.currentTimeMillis();
+        final long startTime = System.currentTimeMillis();
+ 
         try {
              retVal = fn.get();
              if (blocking) {
@@ -151,12 +152,13 @@ class PerfStats {
         } catch (Exception e) {
              e.printStackTrace();
         }
-        endTime = System.currentTimeMillis();
         
         if(retVal == null) {
+            final long endTime = System.currentTimeMillis(); 
             record(length, startTime,  endTime);
         } else {
             retVal = retVal.thenAccept((d) -> {
+                final long endTime = System.currentTimeMillis(); 
                 record(length, startTime, endTime);
             });
         }

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -140,13 +140,6 @@ public class PravegaPerfTest {
 
 
             if (!streamManager.createStream(scopeName, streamName,streamconfig)) {
-               /*
-               if (!streamManager.updateStream(scopeName, streamName,streamconfig)) {
-                   System.out.println("Could not able to update the stream: "+streamName+ " try with another stream Name");
-                   System.exit(1);
-               } 
-               */
-
 
               StreamSegments segments = controller.getCurrentSegments(scopeName, streamName).join();
          
@@ -155,6 +148,17 @@ public class PravegaPerfTest {
 
               if (!recreate ) {
                   System.out.println("The stream: " + streamName + " will be manually scaling to "+ segmentCount+ " segments");
+
+                  /*
+                   * Note that the Upgrade stream API does not change the number of segments; 
+                   * but it indicates with new number of segments.
+                   * after calling update stream , manual scaling is required
+                   */   
+                  if (!streamManager.updateStream(scopeName, streamName,streamconfig)) {
+                      System.out.println("Could not able to update the stream: "+streamName+ " try with another stream Name");
+                      System.exit(1);
+                  }
+
                   final double keyRangeChunk = 1.0 / segmentCount;
                   final Map<Double, Double> keyRanges = IntStream.range(0, segmentCount)
                                                                  .boxed()

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -100,13 +100,6 @@ public class PravegaPerfTest {
 
         parseCmdLine(args);
 
-        // Initialize executor
-        if (fork) {
-           fjexecutor = new ForkJoinPool();
-        } else {
-           executor = Executors.newScheduledThreadPool(producerCount + consumerCount);
-        } 
-        bgexecutor = Executors.newScheduledThreadPool(10);
         try {
             @Cleanup StreamManager streamManager = null;
             StreamConfiguration streamconfig = null;
@@ -130,6 +123,15 @@ public class PravegaPerfTest {
             System.exit(1);
         }
 
+
+        // Initialize executor
+        if (fork) {
+           fjexecutor = new ForkJoinPool();
+        } else {
+           executor = Executors.newScheduledThreadPool(producerCount + consumerCount);
+        }
+
+        bgexecutor = Executors.newScheduledThreadPool(10);
 
         if ( !onlyWrite ) {
             ReaderGroupManager readerGroupManager = null;

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -80,7 +80,11 @@ public class PravegaPerfTest {
     private static int runtimeSec = 10;
     // Should producers use Transaction or not
     private static boolean isTransaction = false;
-    private static int reportingInterval = 200;
+    /*
+     * recommended value for reporting interval ; 
+     * its better to keep 1000ms(1 second) to align with eventspersec 
+     */
+    private static int reportingInterval = 1000;
     private static ScheduledExecutorService executor;
     private static ScheduledExecutorService bgexecutor;
     private static ForkJoinPool  fjexecutor;

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -391,20 +391,10 @@ public class PravegaPerfTest {
                     }
                    
                     // event ingestion
-                    long now = System.currentTimeMillis();
-                    retFuture = produceStats.runAndRecordTime(() -> {
+                    retFuture = produceStats.writeAndRecordTime(() -> {
                                 return fn.apply(key, payload);
                             },
-                            now,
-                            payload.length());
-                    //If it is a blocking call, wait for the ack
-                    if ( blocking ) {
-                        try {
-                            retFuture.get();
-                        } catch (InterruptedException  | ExecutionException e) {
-                            e.printStackTrace();
-                        }
-                    }
+                            payload.length(), blocking);
 
                 }
 
@@ -416,6 +406,7 @@ public class PravegaPerfTest {
                      }
                 } catch (InterruptedException e) {
                     // log exception
+                    e.printStackTrace();
                     System.exit(1);
                 }
 
@@ -425,11 +416,14 @@ public class PravegaPerfTest {
 
             producer.flush();
             // producer.close();
-            try {
-                //Wait for the last packet to get acked
-                retFuture.get();
-            } catch (InterruptedException | ExecutionException e ) {
-                e.printStackTrace();
+            
+            if (!blocking) {
+                try {
+                   //Wait for the last packet to get acked
+                   retFuture.get();
+                } catch (InterruptedException | ExecutionException e ) {
+                   e.printStackTrace();
+                }
             }
         }
 

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -305,12 +305,14 @@ public class PravegaPerfTest {
         void runLoop(BiFunction<String, String, CompletableFuture> fn) {
 
             CompletableFuture retFuture = null;
-            for (int i = 0; i < secondsToRun; i++) {
-                int currentEventsPerSec = 0;
+            final long StartTime = System.currentTimeMillis();
+            final long Mseconds = secondsToRun*1000;
+            long DiffTime = Mseconds;
+
+            do {
 
                 long loopStartTime = System.currentTimeMillis();
-                while ( currentEventsPerSec < eventsPerSec) {
-                    currentEventsPerSec++;
+                for (int i = 0; i < eventsPerSec; i++)  {
 
                     // Construct event payload
                     String val = System.currentTimeMillis() + ", " + producerId + ", " + (int) (Math.random() * 200);
@@ -341,17 +343,17 @@ public class PravegaPerfTest {
                 long timeSpent = System.currentTimeMillis() - loopStartTime;
                 // wait for next event
                 try {
-                    //There is no need for sleep for blocking calls.
-                    if ( !blocking ) {
-                        if ( timeSpent < 1000) {
-                            Thread.sleep(1000 - timeSpent);
-                        }
-                    }
+                     if (timeSpent < 1000) {
+                          Thread.sleep(1000 - timeSpent);
+                     }
                 } catch (InterruptedException e) {
                     // log exception
                     System.exit(1);
                 }
-            }
+                DiffTime = System.currentTimeMillis() - StartTime; 
+ 
+            } while(DiffTime < Mseconds);
+
             producer.flush();
             //producer.close();
             try {

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -377,15 +377,16 @@ public class PravegaPerfTest {
                     // Construct event payload
                     String val = System.currentTimeMillis() + ", " + producerId + ", " + (int) (Math.random() * 200);
                     String payload = String.format("%-" + messageSize + "s", val);
+                    String key;
+                    if (isRandomKey) {
+                        key = Integer.toString(producerId + new Random().nextInt());
+                    } else {
+                        key = Integer.toString(producerId);
+                    }
+                   
                     // event ingestion
                     long now = System.currentTimeMillis();
                     retFuture = produceStats.runAndRecordTime(() -> {
-                                String key;
-                                if (isRandomKey) {
-                                    key = Integer.toString(producerId + new Random().nextInt());
-                                } else {
-                                    key = Integer.toString(producerId);
-                                }
                                 return fn.apply(key, payload);
                             },
                             now,

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -51,8 +51,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.BiFunction;
-
 
 
 
@@ -70,6 +70,7 @@ public class PravegaPerfTest {
     private static ClientFactory factory = null;
     private static boolean onlyWrite = true;
     private static boolean blocking = false;
+    private static boolean fork = true;
     // How many producers should we run concurrently
     private static int producerCount = 20;
     private static int consumerCount = 20;
@@ -81,6 +82,8 @@ public class PravegaPerfTest {
     private static boolean isTransaction = false;
     private static int reportingInterval = 200;
     private static ScheduledExecutorService executor;
+    private static ScheduledExecutorService bgexecutor;
+    private static ForkJoinPool  fjexecutor;
     private static CountDownLatch latch;
     private static boolean runKafka = false;
     private static boolean isRandomKey = false;
@@ -91,8 +94,12 @@ public class PravegaPerfTest {
         parseCmdLine(args);
 
         // Initialize executor
-        executor = Executors.newScheduledThreadPool(producerCount + consumerCount + 10);
-
+        if (fork) {
+           fjexecutor = new ForkJoinPool();
+        } else {
+           executor = Executors.newScheduledThreadPool(producerCount + consumerCount);
+        } 
+        bgexecutor = Executors.newScheduledThreadPool(10);
         try {
             @Cleanup StreamManager streamManager = null;
             streamManager = StreamManager.create(new URI(controllerUri));
@@ -108,7 +115,6 @@ public class PravegaPerfTest {
             e.printStackTrace();
             System.exit(1);
         }
-
 
 
         if ( !onlyWrite ) {
@@ -129,10 +135,10 @@ public class PravegaPerfTest {
                 ReaderWorker reader = new ReaderWorker(i);
                 if(i == 0)
                     reader.cleanupEvents();
-                executor.execute(reader);
+                execute(reader);
             }
             if(consumerCount == 0)
-            readerGroup.initiateCheckpoint(streamName, executor);
+               readerGroup.initiateCheckpoint(streamName, bgexecutor);
         }
         produceStats = new PerfStats("Writing",producerCount * eventsPerSec * runtimeSec, reportingInterval,
                 messageSize);
@@ -150,7 +156,7 @@ public class PravegaPerfTest {
                 workers[i] = new WriterWorker(i, eventsPerSec, runtimeSec,
                         isTransaction, isRandomKey, factory);
             }
-            executor.execute(workers[i]);
+            execute(workers[i]);
 
         }
 
@@ -162,9 +168,9 @@ public class PravegaPerfTest {
             produceStats.printTotal();
         }
 
-        executor.shutdown();
+        shutdown();
         // Wait until all threads are finished.
-        executor.awaitTermination(1, TimeUnit.HOURS);
+        awaitTermination(1, TimeUnit.HOURS);
 
 
         if ( !onlyWrite && consumerCount != 0 ) {
@@ -172,6 +178,33 @@ public class PravegaPerfTest {
         }
         System.exit(0);
     }
+
+   
+    private static void execute(Runnable task ) throws Exception {
+        if (fork) {
+            fjexecutor.execute(task);
+        } else  {
+            executor.execute(task);
+       }
+    }
+
+
+    private static void shutdown() throws Exception {
+        if (fork) {
+           fjexecutor.shutdown();
+        } else  {
+           executor.shutdown();
+       }
+    }
+       
+    private static boolean awaitTermination (long timeout,
+                       TimeUnit unit) throws InterruptedException {
+        if (fork) {
+          return  fjexecutor.awaitTermination(timeout,unit);  
+       } else {
+          return  executor.awaitTermination(timeout,unit); 
+       }    
+    } 
 
     private static void parseCmdLine(String[] args) {
         // create Options object
@@ -190,6 +223,8 @@ public class PravegaPerfTest {
         options.addOption("reporting", true, "Reporting internval");
         options.addOption("randomkey", true, "Set Random key default is one key per producer");
         options.addOption("transactionspercommit", true, "Number of events before a transaction is committed");
+        options.addOption("fork", true, " Use fork join framework for parallel threads");
+
 
         options.addOption("help", false, "Help message");
 
@@ -259,6 +294,9 @@ public class PravegaPerfTest {
                     runKafka = Boolean.parseBoolean(commandline.getOptionValue("kafka"));
                 }
 
+                if (commandline.hasOption("fork")) {
+                    fork = Boolean.parseBoolean(commandline.getOptionValue("fork"));
+                }
             }
         } catch (Exception nfe) {
             System.out.println("Invalid arguments. Starting with default values");
@@ -329,7 +367,7 @@ public class PravegaPerfTest {
                                 return fn.apply(key, payload);
                             },
                             now,
-                            payload.length(), executor);
+                            payload.length());
                     //If it is a blocking call, wait for the ack
                     if ( blocking ) {
                         try {
@@ -434,7 +472,7 @@ public class PravegaPerfTest {
                     if(result.getEvent()!=null) {
                         drainStats.runAndRecordTime(() -> {
                             return null;
-                        }, startTime, result.getEvent().length(), executor);
+                        }, startTime, result.getEvent().length());
                     } else break;
                 }while (true);
                 drainStats.printTotal();
@@ -458,7 +496,7 @@ public class PravegaPerfTest {
                         counter = totalEvents.decrementAndGet();
                          consumeStats.runAndRecordTime(() -> {
                             return null;
-                        }, Long.parseLong(result.getEvent().split(",")[0]), result.getEvent().length(), executor);
+                        }, Long.parseLong(result.getEvent().split(",")[0]), result.getEvent().length());
 
                     }while (counter > 0);
                 } catch (ReinitializationRequiredException e) {

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -95,6 +95,8 @@ public class PravegaPerfTest {
 
     public static void main(String[] args) throws Exception {
 
+        final long StartTime = System.currentTimeMillis();
+
         parseCmdLine(args);
 
         // Initialize executor
@@ -154,11 +156,11 @@ public class PravegaPerfTest {
 
             if ( isTransaction ) {
                 workers[i] = new TransactionWriterWorker(i, eventsPerSec,
-                        runtimeSec,
-                        isTransaction, isRandomKey, transactionPerCommit, factory);
+                        runtimeSec,isTransaction, isRandomKey, 
+                        transactionPerCommit, StartTime, factory);
             } else {
                 workers[i] = new WriterWorker(i, eventsPerSec, runtimeSec,
-                        isTransaction, isRandomKey, factory);
+                        isTransaction, isRandomKey, StartTime, factory);
             }
             execute(workers[i]);
 
@@ -319,13 +321,15 @@ public class PravegaPerfTest {
         private final int eventsPerSec;
         private final int secondsToRun;
         private final boolean isTransaction;
+	private final long StartTime;
 
         WriterWorker(int sensorId, int eventsPerSec, int secondsToRun, boolean isTransaction, boolean isRandomKey,
-                     ClientFactory factory) {
+                     long start, ClientFactory factory) {
             this.producerId = sensorId;
             this.eventsPerSec = eventsPerSec;
             this.secondsToRun = secondsToRun;
             this.isTransaction = isTransaction;
+            this.StartTime = start;
             this.producer = factory.createEventWriter(streamName,
                     new JavaSerializer<String>(),
                     EventWriterConfig.builder().build());
@@ -347,7 +351,6 @@ public class PravegaPerfTest {
         void runLoop(BiFunction<String, String, CompletableFuture> fn) {
 
             CompletableFuture retFuture = null;
-            final long StartTime = System.currentTimeMillis();
             final long Mseconds = secondsToRun*1000;
             long DiffTime = Mseconds;
 
@@ -421,8 +424,8 @@ public class PravegaPerfTest {
         private int eventCount = 0;
 
         TransactionWriterWorker(int sensorId, int eventsPerSec, int secondsToRun, boolean
-                isTransaction, boolean isRandomKey, int transactionsPerCommit, ClientFactory factory) {
-            super(sensorId, eventsPerSec, secondsToRun, isTransaction, isRandomKey, factory);
+                isTransaction, boolean isRandomKey, int transactionsPerCommit, long start, ClientFactory factory) {
+            super(sensorId, eventsPerSec, secondsToRun, isTransaction, isRandomKey, start, factory);
             this.transactionsPerCommit = transactionsPerCommit;
             transaction = producer.beginTxn();
         }


### PR DESCRIPTION
1.	Runtime improvement
•	The time is stamped between the starting and ending of the number of events per sec. if it has taken more time then reduce the iterations to complete the bench-marking with in the time
•	In case if the number of events completes with in second, then thread should wait till remaining time to cross 1 second.

2.	Latency accuracy
•	The time is stamped before and after the write event.
•	In case of blocking writes, the time is stamped before and after the write event and ack


3.	Segments options
•	If the existing segment size is not matching with number of producers then its updated
•	The new option “-segments ”, creates the number of segments which can less than or more than number of producers.
•	The option “-segments ” not supplied then number of segments is set to number of producers


4.	Fork/join option
•	The fork executor service is used to improve the number of processors usage. If the latency is low and higher throughput condition, the execution of the parallel thread improve in chronograph. This condition tries to write more data in parallel.


5.	Manual Scaling
•	If the stream is already existing then stream is scaling input number of segments; by default, the number of producers are set as number of segments
•	If the “-recreate true” is provided, then instead of manual scaling, the existing stream will be sealed, deleted and recreated.
