### PR TITLE
latency, manual scaling, runtime and  segments improvements

### DIFF
--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -140,18 +140,11 @@ class PerfStats {
 
     }
 
-    public CompletableFuture writeAndRecordTime(Supplier<CompletableFuture> fn, int length, boolean blocking ) {
+    public CompletableFuture writeAndRecordTime(Supplier<CompletableFuture> fn, int length) {
         CompletableFuture  retVal=null;
         final long startTime = System.currentTimeMillis();
  
-        try {
-             retVal = fn.get();
-             if (blocking) {
-                  retVal.get();
-             }
-        } catch (Exception e) {
-             e.printStackTrace();
-        }
+        retVal = fn.get();
         
         if(retVal == null) {
             final long endTime = System.currentTimeMillis(); 

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -24,11 +24,6 @@ import java.util.concurrent.Executor;
 import io.pravega.client.stream.TxnFailedException;
 import io.pravega.client.stream.ReinitializationRequiredException;
 
-@FunctionalInterface
-interface SupplierWithCE<T, X extends Exception> {
-    T get() throws X;
-}
-
 class PerfStats {
     final private int messageSize;
     final private String action;
@@ -84,7 +79,7 @@ class PerfStats {
         this.count++;
 
         System.out.printf("%8d records %s, %9.1f records/sec, %9.3f MB/sec, %7.4f ms avg latency.\n",
-                windowCount, action, recsPerSec, mbPerSec, latency);
+            windowCount, action, recsPerSec, mbPerSec, latency);
     }
 
     private void newWindow(long currentNumber) {
@@ -109,8 +104,8 @@ class PerfStats {
         double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);
         //double[] percs = percentiles(this.latencies, 0.5, 0.95, 0.99, 0.999);
         System.out.printf(
-                "%d records %s, %.3f records/sec, %d bytes record size, %.3f MB/sec, %.4f ms avg latency, %.4f ms max latency\n",
-                iteration, action, recsPerSec, messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency);
+            "%d records %s, %.3f records/sec, %d bytes record size, %.3f MB/sec, %.4f ms avg latency, %.4f ms max latency\n",
+            iteration, action, recsPerSec, messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency);
         /*  
         System.out.printf("latencies percentiles:  %.4f ms 50th, %.4f ms 95th, %.4f ms 99th, %.4f ms 99.9th.\n",
                            percs[0], percs[1], percs[2], percs[3]);
@@ -128,26 +123,7 @@ class PerfStats {
         return values;
     }
 
-    public CompletableFuture runAndRecordTime(SupplierWithCE<CompletableFuture, ReinitializationRequiredException> fn, long startTime, int length) throws ReinitializationRequiredException {
-        CompletableFuture retVal = fn.get();
-        if (retVal == null) {
-            final long endTime = System.currentTimeMillis();
-            record(length, startTime, endTime);
-        } else {
-            retVal = retVal.thenAccept((d) -> {
-                final long endTime = System.currentTimeMillis();
-                record(length, startTime, endTime);
-            });
-        }
-        return retVal;
-    }
-
-    public CompletableFuture writeAndRecordTime(SupplierWithCE<CompletableFuture, TxnFailedException> fn, int length) throws TxnFailedException {
-        CompletableFuture retVal = null;
-        final long startTime = System.currentTimeMillis();
-
-        retVal = fn.get();
-
+    public CompletableFuture recordTime(CompletableFuture retVal, long startTime, int length) {
         if (retVal == null) {
             final long endTime = System.currentTimeMillis();
             record(length, startTime, endTime);

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -125,7 +125,7 @@ class PerfStats {
         return values;
     }
 
-    public CompletableFuture runAndRecordTime(Supplier<CompletableFuture> fn, long startTime, int length) {
+    public CompletableFuture runAndRecordTime(Supplier<CompletableFuture> fn, long startTime, int length) throws Exception {
         CompletableFuture  retVal = fn.get();
         if(retVal == null) {
             final long endTime = System.currentTimeMillis();
@@ -140,7 +140,7 @@ class PerfStats {
 
     }
 
-    public CompletableFuture writeAndRecordTime(Supplier<CompletableFuture> fn, int length) {
+    public CompletableFuture writeAndRecordTime(Supplier<CompletableFuture> fn, int length) throws Exception {
         CompletableFuture  retVal=null;
         final long startTime = System.currentTimeMillis();
  

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,26 +46,26 @@ class PerfStats {
     final private long reportingInterval;
 
     public PerfStats(String action, int reportingInterval, int messageSize) {
-           this.action = action;
-           this.start = System.currentTimeMillis();
-           this.windowStartTime = System.currentTimeMillis();
-           this.windowStart = 0;
-           this.iteration = 0;
-           this.latencies = new  ArrayList<Double>();
-           this.maxLatency = 0;
-           this.totalLatency = 0;
-           this.windowCount = 0;
-           this.windowBytes = 0;
-           this.reportingInterval = reportingInterval;
-           this.messageSize = messageSize;
+        this.action = action;
+        this.start = System.currentTimeMillis();
+        this.windowStartTime = System.currentTimeMillis();
+        this.windowStart = 0;
+        this.iteration = 0;
+        this.latencies = new ArrayList<Double>();
+        this.maxLatency = 0;
+        this.totalLatency = 0;
+        this.windowCount = 0;
+        this.windowBytes = 0;
+        this.reportingInterval = reportingInterval;
+        this.messageSize = messageSize;
     }
 
     public synchronized void record(int bytes, long startTime, long endTime) {
         this.iteration++;
         this.windowBytes += bytes;
-        this.windowCount++;        
+        this.windowCount++;
         /* did we arrived at reporting time */
-        if ((endTime - windowStartTime)  >= reportingInterval) {
+        if ((endTime - windowStartTime) >= reportingInterval) {
             printWindow(endTime);
             newWindow(count);
         }
@@ -73,18 +73,18 @@ class PerfStats {
 
     private void printWindow(long endTime) {
         long elapsed = endTime - windowStartTime;
-        double latency=(double)(elapsed / (double) windowCount);
+        double latency = (double) (elapsed / (double) windowCount);
         double recsPerSec = 1000.0 * windowCount / (double) elapsed;
         double mbPerSec = 1000.0 * this.windowBytes / (double) elapsed / (1024.0 * 1024.0);
 
         this.bytes += this.windowBytes;
-        this.totalLatency += latency; 
-        this.maxLatency = Math.max(this.maxLatency, latency); 
+        this.totalLatency += latency;
+        this.maxLatency = Math.max(this.maxLatency, latency);
         this.latencies.add(latency);
         this.count++;
-        
+
         System.out.printf("%8d records %s, %9.1f records/sec, %9.3f MB/sec, %7.4f ms avg latency.\n",
-                           windowCount, action, recsPerSec, mbPerSec, latency);  
+                windowCount, action, recsPerSec, mbPerSec, latency);
     }
 
     private void newWindow(long currentNumber) {
@@ -109,17 +109,17 @@ class PerfStats {
         double mbPerSec = 1000.0 * this.bytes / (double) elapsed / (1024.0 * 1024.0);
         //double[] percs = percentiles(this.latencies, 0.5, 0.95, 0.99, 0.999);
         System.out.printf(
-                "%d records %s, %.3f records/sec, %d bytes record size, %.3f MB/sec, %.4f ms avg latency, %.4f ms max latency\n", 
-                iteration, action, recsPerSec,  messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency);
+                "%d records %s, %.3f records/sec, %d bytes record size, %.3f MB/sec, %.4f ms avg latency, %.4f ms max latency\n",
+                iteration, action, recsPerSec, messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency);
         /*  
         System.out.printf("latencies percentiles:  %.4f ms 50th, %.4f ms 95th, %.4f ms 99th, %.4f ms 99.9th.\n",
                            percs[0], percs[1], percs[2], percs[3]);
         */
-        
+
     }
 
     private double[] percentiles(double[] latencies, double... percentiles) {
-        Arrays.sort(latencies, 0, (int)count);
+        Arrays.sort(latencies, 0, (int) count);
         double[] values = new double[percentiles.length];
         for (int i = 0; i < percentiles.length; i++) {
             int index = (int) (percentiles[i] * count);
@@ -129,36 +129,34 @@ class PerfStats {
     }
 
     public CompletableFuture runAndRecordTime(SupplierWithCE<CompletableFuture, ReinitializationRequiredException> fn, long startTime, int length) throws ReinitializationRequiredException {
-        CompletableFuture  retVal = fn.get();
-        if(retVal == null) {
+        CompletableFuture retVal = fn.get();
+        if (retVal == null) {
             final long endTime = System.currentTimeMillis();
-            record(length,startTime,  endTime);
+            record(length, startTime, endTime);
         } else {
             retVal = retVal.thenAccept((d) -> {
                 final long endTime = System.currentTimeMillis();
-                record(length,startTime, endTime);
-            });
-        }
-        return retVal;
-
-    }
-
-    public CompletableFuture writeAndRecordTime(SupplierWithCE<CompletableFuture, TxnFailedException> fn, int length) throws TxnFailedException {
-        CompletableFuture  retVal=null;
-        final long startTime = System.currentTimeMillis();
-
-        retVal = fn.get();
-
-        if(retVal == null) {
-            final long endTime = System.currentTimeMillis(); 
-            record(length, startTime,  endTime);
-        } else {
-            retVal = retVal.thenAccept((d) -> {
-                final long endTime = System.currentTimeMillis(); 
                 record(length, startTime, endTime);
             });
         }
         return retVal;
     }
 
+    public CompletableFuture writeAndRecordTime(SupplierWithCE<CompletableFuture, TxnFailedException> fn, int length) throws TxnFailedException {
+        CompletableFuture retVal = null;
+        final long startTime = System.currentTimeMillis();
+
+        retVal = fn.get();
+
+        if (retVal == null) {
+            final long endTime = System.currentTimeMillis();
+            record(length, startTime, endTime);
+        } else {
+            retVal = retVal.thenAccept((d) -> {
+                final long endTime = System.currentTimeMillis();
+                record(length, startTime, endTime);
+            });
+        }
+        return retVal;
+    }
 }

--- a/src/main/java/com/emc/pravega/perf/PerfStats.java
+++ b/src/main/java/com/emc/pravega/perf/PerfStats.java
@@ -127,11 +127,12 @@ class PerfStats {
 
     public CompletableFuture runAndRecordTime(Supplier<CompletableFuture> fn, long startTime, int length) {
         CompletableFuture  retVal = fn.get();
-        long endTime = System.currentTimeMillis(); 
         if(retVal == null) {
+            final long endTime = System.currentTimeMillis();
             record(length,startTime,  endTime);
         } else {
             retVal = retVal.thenAccept((d) -> {
+                final long endTime = System.currentTimeMillis();
                 record(length,startTime, endTime);
             });
         }
@@ -141,8 +142,8 @@ class PerfStats {
 
     public CompletableFuture writeAndRecordTime(Supplier<CompletableFuture> fn, int length, boolean blocking ) {
         CompletableFuture  retVal=null;
-        long startTime, endTime;
-        startTime = System.currentTimeMillis();
+        final long startTime = System.currentTimeMillis();
+ 
         try {
              retVal = fn.get();
              if (blocking) {
@@ -151,12 +152,13 @@ class PerfStats {
         } catch (Exception e) {
              e.printStackTrace();
         }
-        endTime = System.currentTimeMillis();
         
         if(retVal == null) {
+            final long endTime = System.currentTimeMillis(); 
             record(length, startTime,  endTime);
         } else {
             retVal = retVal.thenAccept((d) -> {
+                final long endTime = System.currentTimeMillis(); 
                 record(length, startTime, endTime);
             });
         }

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -8,7 +8,7 @@
  * with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -131,13 +131,13 @@ public class PravegaPerfTest {
                 readerGroup = streamHandle.createReaderGroup();
                 drainStats = new PerfStats("Draining", reportingInterval, messageSize);
                 consumeStats = new PerfStats("Reading", reportingInterval, messageSize);
-                PravegaReaderWorker.totalEvents = new AtomicInteger(consumerCount * eventsPerSec * runtimeSec);
 
                 readers = IntStream.range(0, consumerCount)
                                    .boxed()
                                    .map(i -> new PravegaReaderWorker(i, runtimeSec,
                                        StartTime, factory,
-                                       consumeStats, streamName, timeout))
+                                       consumeStats, streamName, timeout,
+                                       consumerCount * eventsPerSec * runtimeSec))
                                    .collect(Collectors.toList());
 
                 if (producerCount > 0) {

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -8,7 +8,7 @@
  * with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaPerfTest.java
@@ -6,15 +6,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.emc.pravega.perf;
 
 import io.pravega.client.ClientConfig;
@@ -34,7 +35,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.concurrent.Callable; 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -54,11 +55,9 @@ import java.util.AbstractMap;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.AbstractMap.SimpleImmutableEntry;
 
-
 /**
  * Performance benchmark for Pravega.
  * Data format is in comma separated format as following: {TimeStamp, Sensor Id, Location, TempValue }.
- *
  */
 public class PravegaPerfTest {
 
@@ -78,141 +77,130 @@ public class PravegaPerfTest {
     private static boolean isRandomKey = false;
     private static int transactionPerCommit = 1;
 
-
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
 
         final long StartTime = System.currentTimeMillis();
-        long endTime; 
-        ReaderGroup readerGroup=null;
-        final int timeout=10;
+        long endTime;
+        ReaderGroup readerGroup = null;
+        final int timeout = 10;
         final ClientFactory factory;
         ControllerImpl controller = null;
         ScheduledExecutorService bgexecutor;
-        ForkJoinPool  fjexecutor;
+        ForkJoinPool fjexecutor;
         final PerfStats produceStats, consumeStats, drainStats;
-        final List <Callable<Void>> readers;
-        final List <Callable<Void>> writers;
-
+        final List<Callable<Void>> readers;
+        final List<Callable<Void>> writers;
 
         try {
             parseCmdLine(args);
-        } catch(ParseException p) {
+        } catch (ParseException p) {
             p.printStackTrace();
             System.exit(1);
         }
         if (producerCount == 0 && consumerCount == 0) {
-           System.out.println("Error: Must specify the number of producers or Consumers");
-           System.exit(1);
+            System.out.println("Error: Must specify the number of producers or Consumers");
+            System.exit(1);
         }
 
         bgexecutor = Executors.newScheduledThreadPool(10);
         fjexecutor = new ForkJoinPool();
-   
- 
+
         try {
 
             controller = new ControllerImpl(ControllerImplConfig.builder()
-                                    .clientConfig(ClientConfig.builder()
-                                    .controllerURI(new URI(controllerUri)).build())
-                                    .maxBackoffMillis(5000).build(),
-                                     bgexecutor);
-               
-            PravegaStreamHandler  streamHandle =  new PravegaStreamHandler(scopeName, streamName, controllerUri,
-                                                             segmentCount, timeout, controller,
-                                                             bgexecutor);
+                                                                .clientConfig(ClientConfig.builder()
+                                                                                          .controllerURI(new URI(controllerUri)).build())
+                                                                .maxBackoffMillis(5000).build(),
+                bgexecutor);
 
-            if (producerCount > 0 &&  !streamHandle.create()) {
-               if (recreate)
-                     streamHandle.recreate();
-               else
-                     streamHandle.scale();                    
+            PravegaStreamHandler streamHandle = new PravegaStreamHandler(scopeName, streamName, controllerUri,
+                segmentCount, timeout, controller,
+                bgexecutor);
+
+            if (producerCount > 0 && !streamHandle.create()) {
+                if (recreate) {
+                    streamHandle.recreate();
+                } else {
+                    streamHandle.scale();
+                }
             }
 
             factory = new ClientFactoryImpl(scopeName, controller);
 
-            if (consumerCount > 0 ) {
-               readerGroup = streamHandle.createReaderGroup();
-               drainStats = new PerfStats("Draining", reportingInterval, messageSize);
-               consumeStats = new PerfStats("Reading", reportingInterval, messageSize);
-               PravegaReaderWorker.totalEvents = new AtomicInteger(consumerCount * eventsPerSec * runtimeSec);
+            if (consumerCount > 0) {
+                readerGroup = streamHandle.createReaderGroup();
+                drainStats = new PerfStats("Draining", reportingInterval, messageSize);
+                consumeStats = new PerfStats("Reading", reportingInterval, messageSize);
+                PravegaReaderWorker.totalEvents = new AtomicInteger(consumerCount * eventsPerSec * runtimeSec);
 
+                readers = IntStream.range(0, consumerCount)
+                                   .boxed()
+                                   .map(i -> new PravegaReaderWorker(i, runtimeSec,
+                                       StartTime, factory,
+                                       consumeStats, streamName, timeout))
+                                   .collect(Collectors.toList());
 
-               readers = IntStream.range(0, consumerCount)
-                                  .boxed()
-                                  .map(i ->  new PravegaReaderWorker(i, runtimeSec,
-                                                             StartTime, factory,
-                                                             consumeStats, streamName, timeout))
-                                  .collect(Collectors.toList());
-
-               if (producerCount > 0) {
-                   PravegaReaderWorker  r =  (PravegaReaderWorker) readers.get(0);
-                   r.cleanupEvents(drainStats);
-               }
+                if (producerCount > 0) {
+                    PravegaReaderWorker r = (PravegaReaderWorker) readers.get(0);
+                    r.cleanupEvents(drainStats);
+                }
             } else {
-              readers = null;
-              drainStats =null;
-              consumeStats = null;
+                readers = null;
+                drainStats = null;
+                consumeStats = null;
             }
 
+            if (producerCount > 0) {
 
-            if ( producerCount > 0) {
+                produceStats = new PerfStats("Writing", reportingInterval, messageSize);
+                if (isTransaction) {
 
-               produceStats = new PerfStats("Writing",reportingInterval, messageSize);
-               if (isTransaction) { 
+                    writers = IntStream.range(0, producerCount)
+                                       .boxed()
+                                       .map(i -> new PravegaTransactionWriterWorker(i, eventsPerSec,
+                                           runtimeSec, isRandomKey,
+                                           messageSize, StartTime,
+                                           factory, produceStats,
+                                           streamName, transactionPerCommit))
+                                       .collect(Collectors.toList());
+                } else {
 
-                   writers = IntStream.range(0, producerCount)
-                              .boxed()
-                              .map(i -> new PravegaTransactionWriterWorker(i, eventsPerSec,
-                                             runtimeSec, isRandomKey,
-                                             messageSize, StartTime,
-                                             factory, produceStats,
-                                             streamName, transactionPerCommit))
-                              .collect(Collectors.toList());
+                    writers = IntStream.range(0, producerCount)
+                                       .boxed()
+                                       .map(i -> new PravegaWriterWorker(i, eventsPerSec,
+                                           runtimeSec, isRandomKey,
+                                           messageSize, StartTime,
+                                           factory, produceStats,
+                                           streamName))
+                                       .collect(Collectors.toList());
+                }
+            } else {
+                writers = null;
+                produceStats = null;
+            }
 
-               } else {
+            final List<Callable<Void>> workers = Stream.of(readers, writers)
+                                                       .filter(x -> x != null)
+                                                       .flatMap(x -> x.stream())
+                                                       .collect(Collectors.toList());
+            fjexecutor.invokeAll(workers);
+            fjexecutor.shutdown();
+            fjexecutor.awaitTermination(runtimeSec, TimeUnit.SECONDS);
+            endTime = System.currentTimeMillis();
+            if (produceStats != null) {
+                produceStats.printAll();
+                produceStats.printTotal(endTime);
+            }
 
-                   writers = IntStream.range(0, producerCount)
-                              .boxed()
-                              .map(i -> new PravegaWriterWorker(i, eventsPerSec,
-                                             runtimeSec, isRandomKey,
-                                             messageSize, StartTime,
-                                             factory, produceStats,
-                                             streamName))
-                              .collect(Collectors.toList());
-              }       
-
-           } else {
-             writers = null;
-             produceStats = null;
-           } 
-
-
-           final List<Callable<Void>> workers = Stream.of(readers, writers)
-                                                      .filter(x -> x != null)
-                                                      .flatMap(x -> x.stream())
-                                                      .collect(Collectors.toList());
-           fjexecutor.invokeAll(workers); 
-           endTime = System.currentTimeMillis();  
-           if(produceStats != null) {
-              produceStats.printAll();
-              produceStats.printTotal(endTime);
-           }
-
-           if ( consumeStats != null ) {
-              consumeStats.printTotal(endTime);
-
-           }
-
+            if (consumeStats != null) {
+                consumeStats.printTotal(endTime);
+            }
         } catch (Exception e) {
             e.printStackTrace();
-        } finally {
-           fjexecutor.shutdown();
-           fjexecutor.awaitTermination(runtimeSec, TimeUnit.SECONDS);
         }
-            
+
         System.exit(0);
     }
-
 
     private static void parseCmdLine(String[] args) throws ParseException {
         // create Options object
@@ -247,66 +235,64 @@ public class PravegaPerfTest {
             System.exit(0);
         } else {
 
-        if (commandline.hasOption("controller")) {
-            controllerUri = commandline.getOptionValue("controller");
-        }
-        if (commandline.hasOption("producers")) {
-            producerCount = Integer.parseInt(commandline.getOptionValue("producers"));
-        }
+            if (commandline.hasOption("controller")) {
+                controllerUri = commandline.getOptionValue("controller");
+            }
+            if (commandline.hasOption("producers")) {
+                producerCount = Integer.parseInt(commandline.getOptionValue("producers"));
+            }
 
-        if (commandline.hasOption("consumers")) {
-            consumerCount = Integer.parseInt(commandline.getOptionValue("consumers"));
-        }
+            if (commandline.hasOption("consumers")) {
+                consumerCount = Integer.parseInt(commandline.getOptionValue("consumers"));
+            }
 
-        if (commandline.hasOption("eventspersec")) {
-            eventsPerSec = Integer.parseInt(commandline.getOptionValue("eventspersec"));
-        }
+            if (commandline.hasOption("eventspersec")) {
+                eventsPerSec = Integer.parseInt(commandline.getOptionValue("eventspersec"));
+            }
 
-        if (commandline.hasOption("runtime")) {
-            runtimeSec = Integer.parseInt(commandline.getOptionValue("runtime"));
-        }
+            if (commandline.hasOption("runtime")) {
+                runtimeSec = Integer.parseInt(commandline.getOptionValue("runtime"));
+            }
 
-        if (commandline.hasOption("transaction")) {
-            isTransaction = Boolean.parseBoolean(commandline.getOptionValue("transaction"));
-        }
+            if (commandline.hasOption("transaction")) {
+                isTransaction = Boolean.parseBoolean(commandline.getOptionValue("transaction"));
+            }
 
-        if (commandline.hasOption("size")) {
-            messageSize = Integer.parseInt(commandline.getOptionValue("size"));
-        }
+            if (commandline.hasOption("size")) {
+                messageSize = Integer.parseInt(commandline.getOptionValue("size"));
+            }
 
-        if (commandline.hasOption("stream")) {
-            streamName = commandline.getOptionValue("stream");
-        }
+            if (commandline.hasOption("stream")) {
+                streamName = commandline.getOptionValue("stream");
+            }
 
-        if (commandline.hasOption("reporting")) {
-            reportingInterval = Integer.parseInt(commandline.getOptionValue("reporting"));
-        }
+            if (commandline.hasOption("reporting")) {
+                reportingInterval = Integer.parseInt(commandline.getOptionValue("reporting"));
+            }
 
-        if (commandline.hasOption("randomkey")) {
-            isRandomKey = Boolean.parseBoolean(commandline.getOptionValue("randomkey"));
-        }
+            if (commandline.hasOption("randomkey")) {
+                isRandomKey = Boolean.parseBoolean(commandline.getOptionValue("randomkey"));
+            }
 
-        if (commandline.hasOption("transactionspercommit")) {
-            transactionPerCommit = Integer.parseInt(commandline.getOptionValue("transactionspercommit"));
-        }
+            if (commandline.hasOption("transactionspercommit")) {
+                transactionPerCommit = Integer.parseInt(commandline.getOptionValue("transactionspercommit"));
+            }
 
-        if (commandline.hasOption("kafka")) {
-            runKafka = Boolean.parseBoolean(commandline.getOptionValue("kafka"));
-        }
+            if (commandline.hasOption("kafka")) {
+                runKafka = Boolean.parseBoolean(commandline.getOptionValue("kafka"));
+            }
 
-        if (commandline.hasOption("segments")) {
-            segmentCount = Integer.parseInt(commandline.getOptionValue("segments"));
-        } else {
-            segmentCount = producerCount;
-        }
+            if (commandline.hasOption("segments")) {
+                segmentCount = Integer.parseInt(commandline.getOptionValue("segments"));
+            } else {
+                segmentCount = producerCount;
+            }
 
-        if (commandline.hasOption("recreate")) {
-            recreate = Boolean.parseBoolean(commandline.getOptionValue("recreate"));
+            if (commandline.hasOption("recreate")) {
+                recreate = Boolean.parseBoolean(commandline.getOptionValue("recreate"));
+            }
         }
-
-        }
-     }
-
+    }
 
     private static class StartLocalService {
         static final int PORT = 9090;

--- a/src/main/java/com/emc/pravega/perf/PravegaReaderWorker.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaReaderWorker.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/emc/pravega/perf/PravegaReaderWorker.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaReaderWorker.java
@@ -58,9 +58,7 @@ public class PravegaReaderWorker implements Callable<Void> {
             event = reader.readNextEvent(timeout);
             ret = event.getEvent();
             if (ret != null) {
-                drainStats.runAndRecordTime(() -> {
-                    return null;
-                }, startTime, ret.length());
+                drainStats.recordTime(null, startTime, ret.length());
             }
         } while (ret != null);
         drainStats.printTotal(System.currentTimeMillis());
@@ -78,9 +76,7 @@ public class PravegaReaderWorker implements Callable<Void> {
                 event = reader.readNextEvent(timeout);
                 ret = event.getEvent();
                 if (ret != null) {
-                    stats.runAndRecordTime(() -> {
-                        return null;
-                    }, Long.parseLong(ret.split(",")[0]), ret.length());
+                    stats.recordTime(null, Long.parseLong(ret.split(",")[0]), ret.length());
                 }
                 counter = totalEvents.decrementAndGet();
                 diffTime = System.currentTimeMillis() - StartTime;

--- a/src/main/java/com/emc/pravega/perf/PravegaReaderWorker.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaReaderWorker.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ExecutionException;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.ClientFactory;
-import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.ReinitializationRequiredException;
@@ -49,7 +49,7 @@ public class PravegaReaderWorker implements Callable<Void> {
         this.totalEvents = totalEvents;
 
         reader = factory.createReader(
-            this.readerId, readergrp, new JavaSerializer<String>(), ReaderConfig.builder().build());
+            this.readerId, readergrp, new UTF8StringSerializer(), ReaderConfig.builder().build());
     }
 
     public void cleanupEvents(PerfStats drainStats) throws ReinitializationRequiredException {

--- a/src/main/java/com/emc/pravega/perf/PravegaReaderWorker.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaReaderWorker.java
@@ -6,16 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 package com.emc.pravega.perf;
 
@@ -29,7 +28,6 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.EventRead;
 import io.pravega.client.stream.ReinitializationRequiredException;
 
-
 public class PravegaReaderWorker implements Callable<Void> {
     public static AtomicInteger totalEvents;
     private final EventStreamReader<String> reader;
@@ -37,20 +35,19 @@ public class PravegaReaderWorker implements Callable<Void> {
     private final long StartTime;
     private final int timeout;
     private final PerfStats stats;
-    String readerId;
+    private final String readerId;
 
-
-    PravegaReaderWorker (int readerId, int secondsToRun, long start,
-                         ClientFactory factory, PerfStats stats,
-                         String readergrp, int timeout) {
+    PravegaReaderWorker(int readerId, int secondsToRun, long start,
+                        ClientFactory factory, PerfStats stats,
+                        String readergrp, int timeout) {
         this.readerId = Integer.toString(readerId);
         this.secondsToRun = secondsToRun;
-        this.StartTime=start;
+        this.StartTime = start;
         this.stats = stats;
         this.timeout = timeout;
 
         reader = factory.createReader(
-                this.readerId, readergrp, new JavaSerializer<String>(), ReaderConfig.builder().build());
+            this.readerId, readergrp, new JavaSerializer<String>(), ReaderConfig.builder().build());
     }
 
     public void cleanupEvents(PerfStats drainStats) throws ReinitializationRequiredException {
@@ -60,35 +57,34 @@ public class PravegaReaderWorker implements Callable<Void> {
             long startTime = System.currentTimeMillis();
             event = reader.readNextEvent(timeout);
             ret = event.getEvent();
-            if(ret !=null) {
+            if (ret != null) {
                 drainStats.runAndRecordTime(() -> {
                     return null;
                 }, startTime, ret.length());
             }
-        }while (ret != null);
+        } while (ret != null);
         drainStats.printTotal(System.currentTimeMillis());
     }
-
 
     @Override
     public Void call() throws ReinitializationRequiredException, ExecutionException {
         EventRead<String> event = null;
         String ret = null;
-        final long mSeconds = secondsToRun*1000;
+        final long mSeconds = secondsToRun * 1000;
         long diffTime = mSeconds;
         int counter = 0;
         try {
             do {
                 event = reader.readNextEvent(timeout);
                 ret = event.getEvent();
-                if(ret != null) {
+                if (ret != null) {
                     stats.runAndRecordTime(() -> {
                         return null;
                     }, Long.parseLong(ret.split(",")[0]), ret.length());
                 }
                 counter = totalEvents.decrementAndGet();
                 diffTime = System.currentTimeMillis() - StartTime;
-            }while ((counter > 0) && (diffTime < mSeconds));
+            } while ((counter > 0) && (diffTime < mSeconds));
         } finally {
             reader.close();
         }

--- a/src/main/java/com/emc/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaStreamHandler.java
@@ -49,8 +49,6 @@ public class PravegaStreamHandler {
     final ControllerImpl controller;
     final StreamManager streamManager;
     final StreamConfiguration streamconfig;
-    ReaderGroupManager readerGroupManager;
-    ReaderGroup readerGroup;
     final ScheduledExecutorService bgexecutor;
     final int segCount;
     final int timeout;
@@ -65,7 +63,6 @@ public class PravegaStreamHandler {
         this.controller = contrl;
         this.segCount = segs;
         this.timeout = timeout;
-        this.readerGroup = null;
         this.bgexecutor = bgexecutor;
         streamManager = StreamManager.create(new URI(uri));
         streamManager.createScope(scope);
@@ -142,18 +139,13 @@ public class PravegaStreamHandler {
     }
 
     ReaderGroup createReaderGroup() throws URISyntaxException {
-        if (readerGroup != null) {
-            return readerGroup;
-        }
-
-        readerGroupManager = ReaderGroupManager.withScope(scope,
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope,
             ClientConfig.builder()
                         .controllerURI(new URI(controllerUri)).build());
         readerGroupManager.createReaderGroup(stream,
             ReaderGroupConfig.builder()
                              .stream(Stream.of(scope, stream))
                              .build());
-        readerGroup = readerGroupManager.getReaderGroup(stream);
-        return readerGroup;
+        return readerGroupManager.getReaderGroup(stream);
     }
 }

--- a/src/main/java/com/emc/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaStreamHandler.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/emc/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaWriterWorker.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/emc/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaWriterWorker.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ExecutionException;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.Transaction;
-import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.TxnFailedException;
 
@@ -50,7 +50,7 @@ public class PravegaWriterWorker implements Callable<Void> {
         this.isRandomKey = isRandomKey;
         this.messageSize = messageSize;
         this.producer = factory.createEventWriter(streamName,
-            new JavaSerializer<String>(),
+            new UTF8StringSerializer(),
             EventWriterConfig.builder().build());
     }
 
@@ -59,12 +59,12 @@ public class PravegaWriterWorker implements Callable<Void> {
      *
      * @return A function which takes String key and data and returns a future object.
      */
-    public CompletableFuture writeData(String key, String data) throws TxnFailedException {
+    public CompletableFuture writeData(String key, String data) throws TxnFailedException, IllegalStateException {
         return producer.writeEvent(key, data);
     }
 
     @Override
-    public Void call() throws TxnFailedException, InterruptedException, ExecutionException {
+    public Void call() throws TxnFailedException, InterruptedException, ExecutionException, IllegalStateException {
         CompletableFuture retFuture = null;
         final long mSeconds = secondsToRun * 1000;
         long diffTime = mSeconds;


### PR DESCRIPTION
This PR is updated with following changes

1. boolean returns are replaced with Exception
2. code cleanup as per Tom's review comments

This PR  Covered Tom's review comments with the following changes
1. The Runnable classes are changed to callable to return the exceptions
       to caller or parent thread.
2. the boolean values and other user inputs are handled at main
3. in case of exception, its stacked back to main and exit; so that its final and single of exit for the benchmarking
4. the "blocking" option is removed as it not required; 
5. the fork join is made the default and thread executor service is removed to improve the cpu usage 
6. the code is refactor to use OO concepts and streams, callables , fork join parallelism effectively


Covered Arvind's review comments on https://github.com/pravega/pravega-benchmark/pull/10

Runtime improvement
•	The time is stamped between the starting and ending of the number of events per sec. if it has taken more time then reduce the iterations to complete the bench-marking with in the time
•	In case if the number of events completes with in second, then thread should wait till remaining time to cross 1 second.

Latency accuracy
•	The start time is stamped before the write event and end time is stamped in the callback thread of the ack of the completable future of write.
•	In case of blocking writes, the time is stamped before and after the write event and ack

Segments options
•	If the existing segment size is not matching with number of producers then its updated
•	The new option “-segments ”, creates the number of segments which can less than or more than number of producers.
•	The option “-segments ” not supplied then number of segments is set to number of producers

Fork/join option
•	The fork executor service is used to improve the number of processors usage. If the latency is low and higher throughput condition, the execution of the parallel thread improve in chronograph. This condition tries to write more data in parallel.

Manual Scaling
•	If the stream is already existing then stream is scaling input number of segments; by default, the number of producers are set as number of segments
•	If the “-recreate true” is provided, then instead of manual scaling, the existing stream will be sealed, deleted and recreated.
