### PR TITLE
The java System.currenttimemillis api invocation are replaced

### DIFF
--- a/src/main/java/com/emc/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaStreamHandler.java
@@ -99,26 +99,26 @@ public class PravegaStreamHandler {
         final Map<Double, Double> keyRanges = IntStream.range(0, segCount)
                                                        .boxed()
                                                        .collect(
-                                                           Collectors
-                                                               .toMap(x -> x * keyRangeChunk,
-                                                                   x -> (x + 1) * keyRangeChunk));
+                                                               Collectors
+                                                                       .toMap(x -> x * keyRangeChunk,
+                                                                               x -> (x + 1) * keyRangeChunk));
         final List<Long> segmentList = segments.getSegments()
                                                .stream()
                                                .map(Segment::getSegmentId)
                                                .collect(Collectors.toList());
 
         CompletableFuture<Boolean> scaleStatus = controller.scaleStream(new StreamImpl(scope, stream),
-            segmentList,
-            keyRanges,
-            bgexecutor).getFuture();
+                segmentList,
+                keyRanges,
+                bgexecutor).getFuture();
 
         if (!scaleStatus.get(timeout, TimeUnit.SECONDS)) {
             throw new TimeoutException("ERROR : Scale operation on stream " + stream + " did not complete");
         }
 
         System.out.println("Number of Segments after manual scale: " +
-            controller.getCurrentSegments(scope, stream)
-                      .get().getSegments().size());
+                controller.getCurrentSegments(scope, stream)
+                          .get().getSegments().size());
     }
 
     void recreate() throws InterruptedException, ExecutionException, TimeoutException {
@@ -140,12 +140,12 @@ public class PravegaStreamHandler {
 
     ReaderGroup createReaderGroup() throws URISyntaxException {
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope,
-            ClientConfig.builder()
-                        .controllerURI(new URI(controllerUri)).build());
+                ClientConfig.builder()
+                            .controllerURI(new URI(controllerUri)).build());
         readerGroupManager.createReaderGroup(stream,
-            ReaderGroupConfig.builder()
-                             .stream(Stream.of(scope, stream))
-                             .build());
+                ReaderGroupConfig.builder()
+                                 .stream(Stream.of(scope, stream))
+                                 .build());
         return readerGroupManager.getReaderGroup(stream);
     }
 }

--- a/src/main/java/com/emc/pravega/perf/PravegaTransactionWriterWorker.java
+++ b/src/main/java/com/emc/pravega/perf/PravegaTransactionWriterWorker.java
@@ -18,6 +18,7 @@
 
 package com.emc.pravega.perf;
 
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.Transaction;
@@ -32,12 +33,14 @@ public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
 
     PravegaTransactionWriterWorker(int sensorId, int eventsPerSec,
                                    int secondsToRun, boolean isRandomKey,
-                                   int messageSize, long start,
+                                   int messageSize, Instant start,
                                    ClientFactory factory, PerfStats stats,
-                                   String streamName, int transactionsPerCommit) {
+                                   String streamName,
+                                   long totalEvents,
+                                   int transactionsPerCommit) {
 
         super(sensorId, eventsPerSec, secondsToRun, isRandomKey,
-            messageSize, start, factory, stats, streamName);
+                messageSize, start, factory, stats, streamName, totalEvents);
 
         this.transactionsPerCommit = transactionsPerCommit;
         eventCount = new AtomicInteger(0);


### PR DESCRIPTION
The java System.currenttimemillis api invocation are replaced by java time instances and duration.
This fix is addressing  this issue : https://github.com/pravega/pravega-benchmark/issues/13 