### PR TITLE
Fixed Pravega artifact versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ buildscript {
 
     dependencies {
 
-        compile "io.pravega:pravega-client:0.5.0-2064.d8dd7cb-SNAPSHOT",
-                "io.pravega:pravega-common:0.5.0-2064.d8dd7cb-SNAPSHOT",
+        compile "io.pravega:pravega-client:0.4.0",
+                "io.pravega:pravega-common:0.4.0",
                 "commons-cli:commons-cli:1.3.1",
                 "org.apache.commons:commons-csv:1.5"
 


### PR DESCRIPTION
**Change log description**
Updated Pravega artifact versions to latest release version.

**Purpose of the change**
Fixes #29.

**What the code does**
Updated `build.gradle` file to point to the last version of Pravega artifacts.

**How to verify it**
Run `./gradlew build` should download the appropriate Pravega jars.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>