### PR TITLE
Kafka benchmarking Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You may obtain a copy of the License at
 
 # Pravega Benchmark Tool
 
-The Pravega benchmark tool used for the performance benchmarking of pravega streaming storage cluster.
+The Pravega benchmark tool used for the performance benchmarking of pravega and Kafka streaming storage clusters.
 This tool performs the throughput and latency analysis for the multi producers/writers and consumers/readers of pravega.
 it also validates the end to end latency. The write and/or read latencies can be stored in a CSV file for later analysis.
 At the end of the performance benchmarking, this tool outputs the 50th, 75th, 95th , 99th and 99.9th latency percentiles.
@@ -55,6 +55,7 @@ usage: pravega-benchmark
                                 producer(s) and/or number of events per
                                 consumer
  -help                          Help message
+ -kafka <arg>                   Kafka Benchmarking
  -producers <arg>               number of producers
  -readcsv <arg>                 csv file to record read latencies
  -recreate <arg>                If the stream is already existing, delete
@@ -166,5 +167,9 @@ The -throughput -1 specifies the writes tries to write the events at the maximum
 ```
 
 ### Recording the latencies to CSV files
-user can use the options "-writecsv  <file name>" to record the latencies of writers and "-readcsv <file name>" for readers.
+User can use the options "-writecsv  <file name>" to record the latencies of writers and "-readcsv <file name>" for readers.
 in case of End to End latency mode, if the user can supply only -readcsv to get the end to end latency in to the csv file.
+
+### Kafka Benchmarking
+User can set the option "-kafka true"  for Kafka Benchmarking. User should create the topics manually before running this for kafka benchmarking.
+Unlike pravega benchmarking, this tool does not create the topic automatically. This tools treats stream name as a topic name.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ usage: pravega-benchmark
  -producers <arg>               number of producers
  -readcsv <arg>                 csv file to record read latencies
  -recreate <arg>                If the stream is already existing, delete
-                                it and recreate it
+                                it and recreate it (not applicable for Kafka)
  -segments <arg>                Number of segments
  -size <arg>                    Size of each message (event or record)
  -stream <arg>                  Stream name

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You may obtain a copy of the License at
 
 # Pravega Benchmark Tool
 
-The Pravega benchmark tool used for the performance benchmarking of pravega and Kafka streaming storage clusters.
+The Pravega benchmark tool used for the performance benchmarking of Pravega and Kafka streaming storage clusters.
 This tool performs the throughput and latency analysis for the multi producers/writers and consumers/readers of pravega.
 it also validates the end to end latency. The write and/or read latencies can be stored in a CSV file for later analysis.
 At the end of the performance benchmarking, this tool outputs the 50th, 75th, 95th , 99th and 99.9th latency percentiles.
@@ -88,8 +88,8 @@ The Pravega benchmark tool can be executed in the following modes:
 ```
 
 ### 1 - Burst Mode
-In this mode, the Pravega benchmark tool pushes/pulls the messages to/from the pravega client as much as possible.
-This mode is used to find the maximum and throughput that can be obtained from the pravega cluster.
+In this mode, the Pravega benchmark tool pushes/pulls the messages to/from the Pravega client as much as possible.
+This mode is used to find the maximum and throughput that can be obtained from the Pravega cluster.
 This mode can be used for both producers and consumers.
 
 ```
@@ -110,8 +110,8 @@ in the case you want to write/read the certain number of events use the -events 
 ```
 
 ### 2 - Throughput Mode
-In this mode, the Pravega benchmark tool pushes the messages to the pravega client with specified approximate maximum throughput in terms of Mega Bytes/second (MB/s).
-This mode is used to find the least latency that can be obtained from the pravega cluster for given throughput.
+In this mode, the Pravega benchmark tool pushes the messages to the Pravega client with specified approximate maximum throughput in terms of Mega Bytes/second (MB/s).
+This mode is used to find the least latency that can be obtained from the Pravega cluster for given throughput.
 This mode is used only for write operation.
 
 ```
@@ -136,8 +136,8 @@ in the case you want to write/read the certain number of events use the -events 
 
 ### 3 - OPS Mode or  Events Rate / Rate Limiter Mode
 This mode is another form of controlling writers throughput by limiting the number of events per second.
-In this mode, the Pravega benchmark tool pushes the messages to the pravega client with specified approximate maximum events per sec.
-This mode is used to find the least latency  that can be obtained from the pravega cluster for events rate.
+In this mode, the Pravega benchmark tool pushes the messages to the Pravega client with specified approximate maximum events per sec.
+This mode is used to find the least latency  that can be obtained from the Pravega cluster for events rate.
 This mode is used only for write operation.
 
 ```
@@ -153,7 +153,7 @@ Note that in this mode, there is 'NO total number of events' to specify hence us
 ```
 
 ### 4 - End to End Latency Mode
-In this mode, the Pravega benchmark tool writes and read the messages to the pravega cluster and records the end to end latency.
+In this mode, the Pravega benchmark tool writes and read the messages to the Pravega cluster and records the end to end latency.
 End to end latency means the time duration between the beginning of the writing event/record to stream and the time after reading the event/record.
 in this mode user must specify both the number of producers and consumers.
 The -throughput option (Throughput mode) or -events (late limiter) can used to limit the writers throughput or events rate.
@@ -172,4 +172,4 @@ in case of End to End latency mode, if the user can supply only -readcsv to get 
 
 ### Kafka Benchmarking
 User can set the option "-kafka true"  for Kafka Benchmarking. User should create the topics manually before running this for kafka benchmarking.
-Unlike pravega benchmarking, this tool does not create the topic automatically. This tools treats stream name as a topic name.
+Unlike Pravega benchmarking, this tool does not create the topic automatically. This tools treats stream name as a topic name.

--- a/README.md
+++ b/README.md
@@ -47,30 +47,31 @@ Running Pravega benchmark tool locally:
 ```
 <dir>/pravega-benchmark$ ./run/pravega-benchmark/bin/pravega-benchmark  -help
 usage: pravega-benchmark
- -consumers <arg>               number of consumers
- -controller <arg>              controller URI
- -events <arg>                  number of events/records if 'time' not
+ -consumers <arg>               Number of consumers
+ -controller <arg>              Controller URI
+ -events <arg>                  Number of events/records if 'time' not
                                 specified;
-                                otherwise, maximum events per second by
-                                producer(s) and/or number of events per
+                                otherwise, Maximum events per second by
+                                producer(s) and/or Number of events per
                                 consumer
+ -flush <arg>                   Number of events/records to flush
  -help                          Help message
  -kafka <arg>                   Kafka Benchmarking
- -producers <arg>               number of producers
- -readcsv <arg>                 csv file to record read latencies
+ -producers <arg>               Number of producers
+ -readcsv <arg>                 CSV file to record read latencies
  -recreate <arg>                If the stream is already existing, delete
-                                it and recreate it (not applicable for Kafka)
+                                it and recreate it (not applicable for
+                                Kafka)
  -segments <arg>                Number of segments
  -size <arg>                    Size of each message (event or record)
  -stream <arg>                  Stream name
  -throughput <arg>              if > 0 , throughput in MB/s
                                 if 0 , writes 'events'
                                 if -1, get the maximum throughput
- -time <arg>                    number of seconds the code runs
- -transaction <arg>             Producers use transactions or not
+ -time <arg>                    Number of seconds the code runs
  -transactionspercommit <arg>   Number of events before a transaction is
                                 committed
- -writecsv <arg>                csv file to record write latencies
+ -writecsv <arg>                CSV file to record write latencies
 ```
 
 ## Running Performance benchmarking

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ usage: pravega-benchmark
                                 otherwise, Maximum events per second by
                                 producer(s) and/or Number of events per
                                 consumer
- -flush <arg>                   Number of events/records to flush
+ -flush <arg>                   Number of events/records to flush per
+                                Producer
  -help                          Help message
  -kafka <arg>                   Kafka Benchmarking
  -producers <arg>               Number of producers

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You may obtain a copy of the License at
 The Pravega benchmark tool used for the performance benchmarking of Pravega and Kafka streaming storage clusters.
 This tool performs the throughput and latency analysis for the multi producers/writers and consumers/readers of pravega.
 it also validates the end to end latency. The write and/or read latencies can be stored in a CSV file for later analysis.
-At the end of the performance benchmarking, this tool outputs the 50th, 75th, 95th , 99th and 99.9th latency percentiles.
+At the end of the performance benchmarking, this tool outputs the 50th, 75th, 95th , 99th, 99.9th and 99.99th latency percentiles.
 
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ usage: pravega-benchmark
                                 producer(s) and/or Number of events per
                                 consumer
  -flush <arg>                   Number of events/records to flush per
-                                Producer
+                                Producer;Not applicable if both producers
+                                and consumers are specified
  -help                          Help message
  -kafka <arg>                   Kafka Benchmarking
  -producers <arg>               Number of producers

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ untar the Pravega benchmark tool to local folder
 tar -xvf ./build/distributions/pravega-benchmark.tar -C ./run
 ```
 
-Running Pravega bencmark tool locally:
+Running Pravega benchmark tool locally:
 
 ```
 <dir>/pravega-benchmark$ ./run/pravega-benchmark/bin/pravega-benchmark  -help

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,8 @@ buildscript {
         compile "io.pravega:pravega-client:0.4.0",
                 "io.pravega:pravega-common:0.4.0",
                 "commons-cli:commons-cli:1.3.1",
-                "org.apache.commons:commons-csv:1.5"
+                "org.apache.commons:commons-csv:1.5",
+                "org.apache.kafka:kafka-clients:2.2.0"
 
         runtime "org.slf4j:slf4j-simple:1.7.14"
     }

--- a/src/main/java/io/pravega/perf/KafkaReaderWorker.java
+++ b/src/main/java/io/pravega/perf/KafkaReaderWorker.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.perf;
+
+import java.util.Properties;
+import java.util.Arrays;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+/**
+ * Class for Kafka reader/consumer.
+ */
+public class KafkaReaderWorker extends ReaderWorker {
+    final private KafkaConsumer<String, String> consumer;
+
+    KafkaReaderWorker(int readerId, int events, int secondsToRun,
+                      long start, PerfStats stats, String partition,
+                      int timeout, boolean writeAndRead, Properties consumerProps) {
+        super(readerId, events, secondsToRun, start, stats, partition, timeout, writeAndRead);
+
+        this.consumer = new KafkaConsumer<>(consumerProps);
+        this.consumer.subscribe(Arrays.asList(partition));
+    }
+
+    @Override
+    public String readData() {
+        final ConsumerRecords<String, String> records = consumer.poll(timeout);
+        if (records.isEmpty()) {
+            return null;
+        }
+        return records.iterator().next().value();
+    }
+
+    @Override
+    public void close() {
+        consumer.close();
+    }
+}

--- a/src/main/java/io/pravega/perf/KafkaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/KafkaWriterWorker.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.perf;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+/**
+ * Class for Kafka writer/producer.
+ */
+public class KafkaWriterWorker extends WriterWorker {
+    final private KafkaProducer<String, String> producer;
+
+    KafkaWriterWorker(int sensorId, int events, int secondsToRun,
+                      boolean isRandomKey, int messageSize, long start,
+                      PerfStats stats, String streamName, int eventsPerSec,
+                      boolean writeAndRead, Properties producerProps) {
+
+        super(sensorId, events, secondsToRun,
+                isRandomKey, messageSize, start,
+                stats, streamName, eventsPerSec, writeAndRead);
+
+        this.producer = new KafkaProducer<>(producerProps);
+    }
+
+    public long recordWrite(String data, TriConsumer record) {
+        final long time = System.currentTimeMillis();
+        producer.send(new ProducerRecord<>(streamName, data), (metadata, exception) -> {
+            record.accept(time, System.currentTimeMillis(), data.length());
+        });
+        return time;
+    }
+
+    @Override
+    public void writeData(String data) {
+        producer.send(new ProducerRecord<>(streamName, data));
+        /*
+          flush is required here for following reasons:
+          1. The writeData is called for End to End latency mode; hence make sure that data is sent.
+          2. kafka buffering makes the too many writes; flushing will moderate the kafka producer.
+          3. If the flush called after several iterations, then flush will take too much of time.
+         */
+        flush();
+    }
+
+
+    @Override
+    public void flush() {
+        producer.flush();
+    }
+}

--- a/src/main/java/io/pravega/perf/KafkaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/KafkaWriterWorker.java
@@ -43,13 +43,6 @@ public class KafkaWriterWorker extends WriterWorker {
     @Override
     public void writeData(String data) {
         producer.send(new ProducerRecord<>(streamName, data));
-        /*
-          flush is required here for following reasons:
-          1. The writeData is called for End to End latency mode; hence make sure that data is sent.
-          2. kafka buffering makes the too many writes; flushing will moderate the kafka producer.
-          3. If the flush called after several iterations, then flush will take too much of time.
-         */
-        flush();
     }
 
 

--- a/src/main/java/io/pravega/perf/KafkaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/KafkaWriterWorker.java
@@ -20,14 +20,14 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 public class KafkaWriterWorker extends WriterWorker {
     final private KafkaProducer<String, String> producer;
 
-    KafkaWriterWorker(int sensorId, int events, int secondsToRun,
-                      boolean isRandomKey, int messageSize, long start,
-                      PerfStats stats, String streamName, int eventsPerSec,
-                      boolean writeAndRead, Properties producerProps) {
+    KafkaWriterWorker(int sensorId, int events, int flushEvents,
+                      int secondsToRun, boolean isRandomKey, int messageSize,
+                      long start, PerfStats stats, String streamName,
+                      int eventsPerSec, boolean writeAndRead, Properties producerProps) {
 
-        super(sensorId, events, secondsToRun,
-                isRandomKey, messageSize, start,
-                stats, streamName, eventsPerSec, writeAndRead);
+        super(sensorId, events, flushEvents,
+                secondsToRun, isRandomKey, messageSize,
+                start, stats, streamName, eventsPerSec, writeAndRead);
 
         this.producer = new KafkaProducer<>(producerProps);
     }

--- a/src/main/java/io/pravega/perf/KafkaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/KafkaWriterWorker.java
@@ -50,4 +50,9 @@ public class KafkaWriterWorker extends WriterWorker {
     public void flush() {
         producer.flush();
     }
+
+    @Override
+    public void close() {
+        producer.close();
+    }
 }

--- a/src/main/java/io/pravega/perf/KafkaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/KafkaWriterWorker.java
@@ -52,7 +52,7 @@ public class KafkaWriterWorker extends WriterWorker {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         producer.close();
     }
 }

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -255,6 +255,7 @@ public class PerfStats {
         }
 
         public void record(int bytes, int latency) {
+            assert latency < latencies.length : "Invalid latency";
             totalBytes += bytes;
             latencies[latency]++;
         }

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -189,7 +189,7 @@ public class PerfStats {
         final static int MS_PER_SEC = 1000;
         final static int MS_PER_MIN = MS_PER_SEC * 60;
         final static int MS_PER_HR = MS_PER_MIN * 60;
-        final double[] percentiles = {0.5, 0.75, 0.95, 0.99, 0.999};
+        final double[] percentiles = {0.5, 0.75, 0.95, 0.99, 0.999, 0.9999};
         final String action;
         final int messageSize;
         final long startTime;
@@ -274,9 +274,9 @@ public class PerfStats {
 
             System.out.printf(
                     "%d records %s, %.3f records/sec, %d bytes record size, %.2f MB/sec, %.1f ms avg latency, %.1f ms max latency" +
-                            ", %d ms 50th, %d ms 75th, %d ms 95th, %d ms 99th, %d ms 99.9th\n",
+                            ", %d ms 50th, %d ms 75th, %d ms 95th, %d ms 99th, %d ms 99.9th, %d ms 99.99th.\n",
                     count, action, recsPerSec, messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency,
-                    percs[0], percs[1], percs[2], percs[3], percs[4]);
+                    percs[0], percs[1], percs[2], percs[3], percs[4], percs[5]);
         }
     }
 

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -80,6 +80,7 @@ public class PerfStats {
      * Private class for start and end time.
      */
     final private class QueueProcessor implements Callable {
+        final private static int PARK_NS = 1000;
         final private long startTime;
 
         private QueueProcessor(long startTime) {
@@ -106,7 +107,7 @@ public class PerfStats {
                     }
                     time = t.endTime;
                 } else {
-                    LockSupport.parkNanos(500);
+                    LockSupport.parkNanos(PARK_NS);
                     time = System.currentTimeMillis();
                 }
                 if (window.windowTimeMS(time) > windowInterval) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -119,7 +119,7 @@ public class PravegaPerfTest {
             final List<WriterWorker> producers = perfTest.getProducers();
             final List<ReaderWorker> consumers = perfTest.getConsumers();
 
-            final List<Callable<Void>> workers = Stream.of(producers, consumers)
+            final List<Callable<Void>> workers = Stream.of(consumers, producers)
                     .filter(x -> x != null)
                     .flatMap(x -> x.stream())
                     .collect(Collectors.toList());

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -77,7 +77,7 @@ public class PravegaPerfTest {
                         "otherwise, Maximum events per second by producer(s) " +
                         "and/or Number of events per consumer");
         options.addOption("flush", true,
-                "Number of events/records to flush");
+                "Number of events/records to flush per Producer");
         options.addOption("time", true, "Number of seconds the code runs");
         options.addOption("transactionspercommit", true,
                 "Number of events before a transaction is committed");
@@ -201,7 +201,6 @@ public class PravegaPerfTest {
         final int consumerCount;
         final int segmentCount;
         final int events;
-        final int flushEvents;
         final int eventsPerSec;
         final int eventsPerProducer;
         final int eventsPerConsumer;
@@ -242,9 +241,14 @@ public class PravegaPerfTest {
             }
 
             if (commandline.hasOption("flush")) {
-                flushEvents = Integer.parseInt(commandline.getOptionValue("flush"));
+                int flushEvents = Integer.parseInt(commandline.getOptionValue("flush"));
+                if (flushEvents > 0) {
+                    flushEventsPerProducer = flushEvents;
+                } else {
+                    flushEventsPerProducer = Integer.MAX_VALUE;
+                }
             } else {
-                flushEvents = Integer.MAX_VALUE;
+                flushEventsPerProducer = Integer.MAX_VALUE;
             }
 
             if (commandline.hasOption("time")) {
@@ -320,17 +324,6 @@ public class PravegaPerfTest {
                     produceStats = new PerfStats("Writing", REPORTINGINTERVAL, messageSize, writeFile);
                 }
 
-                if (flushEvents < Integer.MAX_VALUE) {
-                    int perProducer = flushEvents / producerCount;
-                    if (perProducer < 1) {
-                        flushEventsPerProducer = 1;
-                    } else {
-                        flushEventsPerProducer = perProducer;
-                    }
-                } else {
-                    flushEventsPerProducer = Integer.MAX_VALUE;
-                }
-
                 eventsPerProducer = (events + producerCount - 1) / producerCount;
                 if (throughput < 0 && runtimeSec > 0) {
                     eventsPerSec = events / producerCount;
@@ -344,7 +337,6 @@ public class PravegaPerfTest {
                 eventsPerProducer = 0;
                 eventsPerSec = 0;
                 writeAndRead = false;
-                flushEventsPerProducer = Integer.MAX_VALUE;
             }
 
             if (consumerCount > 0) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -19,6 +19,7 @@ import io.pravega.client.stream.impl.ClientFactoryImpl;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
@@ -45,6 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
 import java.util.Properties;
+import java.util.Locale;
 
 /**
  * Performance benchmark for Pravega.
@@ -465,6 +467,8 @@ public class PravegaPerfTest {
             props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
             props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
             props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
+            // Enabling the consumer to READ_COMMITTED is must to compare between Kafka and Pravega
+            props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT));
             if (writeAndRead) {
                 props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
                 props.put(ConsumerConfig.GROUP_ID_CONFIG, streamName);

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -77,7 +77,8 @@ public class PravegaPerfTest {
                         "otherwise, Maximum events per second by producer(s) " +
                         "and/or Number of events per consumer");
         options.addOption("flush", true,
-                "Number of events/records to flush per Producer");
+                "Number of events/records to flush per Producer;" +
+                        "Not applicable if both producers and consumers are specified");
         options.addOption("time", true, "Number of seconds the code runs");
         options.addOption("transactionspercommit", true,
                 "Number of events before a transaction is committed");

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -395,7 +395,7 @@ public class PravegaPerfTest {
                 }
             }
             if (consumerCount > 0) {
-                readerGroup = streamHandle.createReaderGroup();
+                readerGroup = streamHandle.createReaderGroup(!writeAndRead);
             } else {
                 readerGroup = null;
             }

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -327,7 +327,7 @@ public class PravegaPerfTest {
         }
 
         private void start(long startTime) throws IOException {
-            if (produceStats != null && consumeStats == null) {
+            if (produceStats != null && !writeAndRead) {
                 produceStats.start(startTime);
             }
             if (consumeStats != null) {
@@ -337,7 +337,7 @@ public class PravegaPerfTest {
 
         private void shutdown(long endTime) {
             try {
-                if (produceStats != null && consumeStats == null) {
+                if (produceStats != null && !writeAndRead) {
                     produceStats.shutdown(endTime);
                 }
                 if (consumeStats != null) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -116,8 +116,8 @@ public class PravegaPerfTest {
         final ForkJoinPool executor = new ForkJoinPool();
 
         try {
-            final List<Callable<Void>> producers = perfTest.getProducers();
-            final List<Callable<Void>> consumers = perfTest.getConsumers();
+            final List<WriterWorker> producers = perfTest.getProducers();
+            final List<ReaderWorker> consumers = perfTest.getConsumers();
 
             final List<Callable<Void>> workers = Stream.of(producers, consumers)
                     .filter(x -> x != null)
@@ -131,6 +131,12 @@ public class PravegaPerfTest {
                         executor.shutdown();
                         executor.awaitTermination(1, TimeUnit.SECONDS);
                         perfTest.shutdown(System.currentTimeMillis());
+                        if (consumers != null) {
+                            consumers.forEach(ReaderWorker::close);
+                        }
+                        if (producers != null) {
+                            producers.forEach(WriterWorker::close);
+                        }
                     } catch (InterruptedException ex) {
                         ex.printStackTrace();
                     }
@@ -141,6 +147,12 @@ public class PravegaPerfTest {
             executor.shutdown();
             executor.awaitTermination(1, TimeUnit.SECONDS);
             perfTest.shutdown(System.currentTimeMillis());
+            if (consumers != null) {
+                consumers.forEach(ReaderWorker::close);
+            }
+            if (producers != null) {
+                producers.forEach(WriterWorker::close);
+            }
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -350,9 +362,9 @@ public class PravegaPerfTest {
             }
         }
 
-        public abstract List<Callable<Void>> getProducers();
+        public abstract List<WriterWorker> getProducers();
 
-        public abstract List<Callable<Void>> getConsumers() throws URISyntaxException;
+        public abstract List<ReaderWorker> getConsumers() throws URISyntaxException;
 
     }
 
@@ -391,8 +403,8 @@ public class PravegaPerfTest {
             factory = new ClientFactoryImpl(scopeName, controller);
         }
 
-        public List<Callable<Void>> getProducers() {
-            final List<Callable<Void>> writers;
+        public List<WriterWorker> getProducers() {
+            final List<WriterWorker> writers;
 
             if (producerCount > 0) {
                 if (transactionPerCommit > 0) {
@@ -422,8 +434,8 @@ public class PravegaPerfTest {
             return writers;
         }
 
-        public List<Callable<Void>> getConsumers() throws URISyntaxException {
-            final List<Callable<Void>> readers;
+        public List<ReaderWorker> getConsumers() throws URISyntaxException {
+            final List<ReaderWorker> readers;
             if (consumerCount > 0) {
                 readers = IntStream.range(0, consumerCount)
                         .boxed()
@@ -493,8 +505,8 @@ public class PravegaPerfTest {
         }
 
 
-        public List<Callable<Void>> getProducers() {
-            final List<Callable<Void>> writers;
+        public List<WriterWorker> getProducers() {
+            final List<WriterWorker> writers;
 
             if (producerCount > 0) {
                 if (transactionPerCommit > 0) {
@@ -515,8 +527,8 @@ public class PravegaPerfTest {
             return writers;
         }
 
-        public List<Callable<Void>> getConsumers() throws URISyntaxException {
-            final List<Callable<Void>> readers;
+        public List<ReaderWorker> getConsumers() throws URISyntaxException {
+            final List<ReaderWorker> readers;
             if (consumerCount > 0) {
                 readers = IntStream.range(0, consumerCount)
                         .boxed()

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -451,6 +451,8 @@ public class PravegaPerfTest {
             props.put(ProducerConfig.ACKS_CONFIG, "all");
             props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
             props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+            // Enabling the producer IDEMPOTENCE is must to compare between Kafka and Pravega
+            props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
             return props;
         }
 

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -321,7 +321,12 @@ public class PravegaPerfTest {
                 }
 
                 if (flushEvents < Integer.MAX_VALUE) {
-                    flushEventsPerProducer = flushEvents / producerCount;
+                    int perProducer = flushEvents / producerCount;
+                    if (perProducer < 1) {
+                        flushEventsPerProducer = 1;
+                    } else {
+                        flushEventsPerProducer = perProducer;
+                    }
                 } else {
                     flushEventsPerProducer = Integer.MAX_VALUE;
                 }

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -449,7 +449,6 @@ public class PravegaPerfTest {
             final Properties props = new Properties();
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, controllerUri);
             props.put(ProducerConfig.ACKS_CONFIG, "all");
-            props.put(ProducerConfig.RETRIES_CONFIG, 0);
             props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
             props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
             return props;

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -81,7 +81,7 @@ public class PravegaPerfTest {
         options.addOption("segments", true, "Number of segments");
         options.addOption("size", true, "Size of each message (event or record)");
         options.addOption("recreate", true,
-                "If the stream is already existing, delete it and recreate it");
+                "If the stream is already existing, delete it and recreate it (not applicable for Kafka)");
         options.addOption("throughput", true,
                 "if > 0 , throughput in MB/s\n" +
                         "if 0 , writes 'events'\n" +

--- a/src/main/java/io/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamHandler.java
@@ -36,7 +36,7 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.Stream;
 
 /**
- *  Class for Pravega stream and segments.
+ * Class for Pravega stream and segments.
  */
 public class PravegaStreamHandler {
     final String scope;
@@ -134,14 +134,16 @@ public class PravegaStreamHandler {
         }
     }
 
-    ReaderGroup createReaderGroup() throws URISyntaxException {
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope,
-                ClientConfig.builder()
-                        .controllerURI(new URI(controllerUri)).build());
-        readerGroupManager.createReaderGroup(stream,
-                ReaderGroupConfig.builder()
-                        .stream(Stream.of(scope, stream))
-                        .build());
-        return readerGroupManager.getReaderGroup(stream);
+    ReaderGroup createReaderGroup(boolean reset) throws URISyntaxException {
+        final ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope,
+                ClientConfig.builder().controllerURI(new URI(controllerUri)).build());
+        final ReaderGroupConfig rdGrpConfig = ReaderGroupConfig.builder()
+                            .stream(Stream.of(scope, stream)).build();
+        readerGroupManager.createReaderGroup(stream, rdGrpConfig);
+        final ReaderGroup rdGroup = readerGroupManager.getReaderGroup(stream);
+        if (reset) {
+            rdGroup.resetReaderGroup(rdGrpConfig);
+        }
+        return rdGroup;
     }
 }

--- a/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
@@ -13,6 +13,7 @@ package io.pravega.perf;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TxnFailedException;
+
 import javax.annotation.concurrent.GuardedBy;
 
 public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
@@ -30,7 +31,7 @@ public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
                                    PerfStats stats, String streamName, int eventsPerSec, boolean writeAndRead,
                                    ClientFactory factory, int transactionsPerCommit) {
 
-        super(sensorId, events, secondsToRun, isRandomKey,
+        super(sensorId, events, Integer.MAX_VALUE, secondsToRun, isRandomKey,
                 messageSize, start, stats, streamName, eventsPerSec, writeAndRead, factory);
 
         this.transactionsPerCommit = transactionsPerCommit;

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -59,7 +59,7 @@ public class PravegaWriterWorker extends WriterWorker {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         producer.close();
     }
 }

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -51,7 +51,6 @@ public class PravegaWriterWorker extends WriterWorker {
     @Override
     public void writeData(String data) {
         producer.writeEvent(data);
-        flush();
     }
 
     @Override

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -51,6 +51,7 @@ public class PravegaWriterWorker extends WriterWorker {
     @Override
     public void writeData(String data) {
         producer.writeEvent(data);
+        flush();
     }
 
     @Override

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -57,4 +57,9 @@ public class PravegaWriterWorker extends WriterWorker {
     public void flush() {
         producer.flush();
     }
+
+    @Override
+    public void close() {
+        producer.close();
+    }
 }

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -23,13 +23,13 @@ import io.pravega.client.stream.EventWriterConfig;
 public class PravegaWriterWorker extends WriterWorker {
     final EventStreamWriter<String> producer;
 
-    PravegaWriterWorker(int sensorId, int events, int secondsToRun,
+    PravegaWriterWorker(int sensorId, int events, int flushEvents, int secondsToRun,
                         boolean isRandomKey, int messageSize, long start,
                         PerfStats stats, String streamName, int eventsPerSec,
                         boolean writeAndRead, ClientFactory factory) {
 
-        super(sensorId, events, secondsToRun,
-                isRandomKey, messageSize, start,
+        super(sensorId, events, flushEvents,
+                secondsToRun, isRandomKey, messageSize, start,
                 stats, streamName, eventsPerSec, writeAndRead);
 
         this.producer = factory.createEventWriter(streamName,

--- a/src/main/java/io/pravega/perf/ReaderWorker.java
+++ b/src/main/java/io/pravega/perf/ReaderWorker.java
@@ -23,8 +23,7 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
 
     ReaderWorker(int readerId, int events, int secondsToRun, long start,
                  PerfStats stats, String readergrp, int timeout, boolean writeAndRead) {
-        super(readerId, events, Integer.MAX_VALUE, secondsToRun,
-                0, start, stats, readergrp, timeout);
+        super(readerId, events, secondsToRun, 0, start, stats, readergrp, timeout);
 
         perf = secondsToRun > 0 ? (writeAndRead ? new EventsTimeReaderRW() : new EventsTimeReader()) :
                 (writeAndRead ? new EventsReaderRW() : new EventsReader());

--- a/src/main/java/io/pravega/perf/ReaderWorker.java
+++ b/src/main/java/io/pravega/perf/ReaderWorker.java
@@ -69,12 +69,13 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
         public void benchmark() throws IOException {
             String ret = null;
             try {
-                for (int i = 0; i < events; i++) {
+                for (int i = 0; i < events; ) {
                     ret = readData();
                     if (ret != null) {
                         final long endTime = System.currentTimeMillis();
-                        final long startTime = Long.parseLong(ret.substring(0, TIME_HEADER_SIZE));
-                        stats.recordTime(startTime, endTime, ret.length());
+                        final long start = Long.parseLong(ret.substring(0, TIME_HEADER_SIZE));
+                        stats.recordTime(start, endTime, ret.length());
+                        i++;
                     }
                 }
             } finally {
@@ -91,7 +92,6 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
             long time = System.currentTimeMillis();
 
             try {
-
                 while ((time - startTime) < msToRun) {
                     time = System.currentTimeMillis();
                     ret = readData();
@@ -113,9 +113,9 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
             try {
                 while ((time - startTime) < msToRun) {
                     ret = readData();
+                    time = System.currentTimeMillis();
                     if (ret != null) {
-                        time = System.currentTimeMillis();
-                        final long startTime = Long.parseLong(ret.substring(0, TIME_HEADER_SIZE));
+                        final long start = Long.parseLong(ret.substring(0, TIME_HEADER_SIZE));
                         stats.recordTime(startTime, time, ret.length());
                     }
                 }

--- a/src/main/java/io/pravega/perf/ReaderWorker.java
+++ b/src/main/java/io/pravega/perf/ReaderWorker.java
@@ -52,11 +52,13 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
         public void benchmark() throws IOException {
             String ret = null;
             try {
-                for (int i = 0; i < events; i++) {
+                int i = 0;
+                while (i < events) {
                     final long startTime = System.currentTimeMillis();
                     ret = readData();
                     if (ret != null) {
                         stats.recordTime(startTime, System.currentTimeMillis(), ret.length());
+                        i++;
                     }
                 }
             } finally {
@@ -69,7 +71,8 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
         public void benchmark() throws IOException {
             String ret = null;
             try {
-                for (int i = 0; i < events; ) {
+                int i = 0;
+                while (i < events) {
                     ret = readData();
                     if (ret != null) {
                         final long endTime = System.currentTimeMillis();

--- a/src/main/java/io/pravega/perf/ReaderWorker.java
+++ b/src/main/java/io/pravega/perf/ReaderWorker.java
@@ -23,7 +23,7 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
 
     ReaderWorker(int readerId, int events, int secondsToRun, long start,
                  PerfStats stats, String readergrp, int timeout, boolean writeAndRead) {
-        super(readerId, events, secondsToRun,
+        super(readerId, events, Integer.MAX_VALUE, secondsToRun,
                 0, start, stats, readergrp, timeout);
 
         perf = secondsToRun > 0 ? (writeAndRead ? new EventsTimeReaderRW() : new EventsTimeReader()) :

--- a/src/main/java/io/pravega/perf/Worker.java
+++ b/src/main/java/io/pravega/perf/Worker.java
@@ -11,11 +11,12 @@
 package io.pravega.perf;
 
 /**
- *  Abstract class for Writers and Readers.
+ * Abstract class for Writers and Readers.
  */
 public abstract class Worker {
     final int workerID;
     final int events;
+    final int flushEvents;
     final int messageSize;
     final int timeout;
     final String streamName;
@@ -23,11 +24,12 @@ public abstract class Worker {
     final PerfStats stats;
     final int secondsToRun;
 
-    Worker(int sensorId, int events, int secondsToRun,
-           int messageSize, long start, PerfStats stats,
+    Worker(int sensorId, int events, int flushEvents,
+           int secondsToRun, int messageSize, long start, PerfStats stats,
            String streamName, int timeout) {
         this.workerID = sensorId;
         this.events = events;
+        this.flushEvents = flushEvents;
         this.secondsToRun = secondsToRun;
         this.startTime = start;
         this.stats = stats;

--- a/src/main/java/io/pravega/perf/Worker.java
+++ b/src/main/java/io/pravega/perf/Worker.java
@@ -16,7 +16,6 @@ package io.pravega.perf;
 public abstract class Worker {
     final int workerID;
     final int events;
-    final int flushEvents;
     final int messageSize;
     final int timeout;
     final String streamName;
@@ -24,12 +23,11 @@ public abstract class Worker {
     final PerfStats stats;
     final int secondsToRun;
 
-    Worker(int sensorId, int events, int flushEvents,
-           int secondsToRun, int messageSize, long start, PerfStats stats,
+    Worker(int sensorId, int events, int secondsToRun,
+           int messageSize, long start, PerfStats stats,
            String streamName, int timeout) {
         this.workerID = sensorId;
         this.events = events;
-        this.flushEvents = flushEvents;
         this.secondsToRun = secondsToRun;
         this.startTime = start;
         this.stats = stats;

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -101,6 +101,14 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
                 final String header = String.format(TIME_HEADER_FORMAT, System.currentTimeMillis());
                 final String data = buffer.replace(0, TIME_HEADER_SIZE, header).toString();
                 writeData(data);
+                /*
+                flush is required here for following reasons:
+                1. The writeData is called for End to End latency mode; hence make sure that data is sent.
+                2. In case of kafka benchmarking, the buffering makes the too many writes;
+                   flushing will moderate the kafka producer.
+                3. If the flush called after several iterations, then flush will take too much of time.
+                */
+                flush();
                 eCnt.control(i);
             }
         }
@@ -135,6 +143,14 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
                 final String header = String.format(TIME_HEADER_FORMAT, time);
                 final String data = buffer.replace(0, TIME_HEADER_SIZE, header).toString();
                 writeData(data);
+                /*
+                flush is required here for following reasons:
+                1. The writeData is called for End to End latency mode; hence make sure that data is sent.
+                2. In case of kafka benchmarking, the buffering makes the too many writes;
+                   flushing will moderate the kafka producer.
+                3. If the flush called after several iterations, then flush will take too much of time.
+                */
+                flush();
                 eCnt.control(i);
             }
         }

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -71,6 +71,12 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
      */
     public abstract void flush();
 
+    /**
+     * Flush the producer data.
+     */
+    public abstract void close();
+
+
     @Override
     public Void call() throws InterruptedException, ExecutionException, IOException {
         perf.benchmark();

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -131,24 +131,15 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
             final long msToRun = secondsToRun * MS_PER_SEC;
             long time = System.currentTimeMillis();
             final EventsController eCnt = new EventsController(time, eventsPerSec);
-
-            if (flushEvents < Integer.MAX_VALUE) {
-                int i = 0;
-                while ((time - startTime) < msToRun) {
+            long msElapsed = time - startTime;
+            while (msElapsed < msToRun) {
+                for (int i = 0; (msElapsed < msToRun) && (i < flushEvents); i++) {
                     time = recordWrite(payload, stats::recordTime);
                     eCnt.control(i, time);
-                    i++;
-                    if ((i % flushEvents) == 0) {
-                        flush();
-                    }
+                    msElapsed = time - startTime;
                 }
-            } else {
-                for (int i = 0; (time - startTime) < msToRun; i++) {
-                    time = recordWrite(payload, stats::recordTime);
-                    eCnt.control(i, time);
-                }
+                flush();
             }
-            flush();
         }
     }
 

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -51,7 +51,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     /**
-     * Writes the data and benchmark
+     * Writes the data and benchmark.
      *
      * @param data   data to write
      * @param record to call for benchmarking
@@ -60,7 +60,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
     public abstract long recordWrite(String data, TriConsumer record);
 
     /**
-     * Writes the data and benchmark
+     * Writes the data and benchmark.
      *
      * @param data data to write
      */
@@ -103,7 +103,6 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
                 writeData(data);
                 eCnt.control(i);
             }
-            flush();
         }
     }
 
@@ -138,7 +137,6 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
                 writeData(data);
                 eCnt.control(i);
             }
-            flush();
         }
     }
 

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -104,9 +104,9 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
                 /*
                 flush is required here for following reasons:
                 1. The writeData is called for End to End latency mode; hence make sure that data is sent.
-                2. In case of kafka benchmarking, the buffering makes the too many writes;
-                   flushing will moderate the kafka producer.
-                3. If the flush called after several iterations, then flush will take too much of time.
+                2. In case of kafka benchmarking, the buffering makes too many writes;
+                   flushing moderates the kafka producer.
+                3. If the flush called after several iterations, then flush may take too much of time.
                 */
                 flush();
                 eCnt.control(i);
@@ -146,9 +146,9 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
                 /*
                 flush is required here for following reasons:
                 1. The writeData is called for End to End latency mode; hence make sure that data is sent.
-                2. In case of kafka benchmarking, the buffering makes the too many writes;
-                   flushing will moderate the kafka producer.
-                3. If the flush called after several iterations, then flush will take too much of time.
+                2. In case of kafka benchmarking, the buffering makes too many writes;
+                   flushing moderates the kafka producer.
+                3. If the flush called after several iterations, then flush may take too much of time.
                 */
                 flush();
                 eCnt.control(i);


### PR DESCRIPTION
Change log description
The existing pravega bench marking tool is extended to do the Kafka bench marking.

Purpose of the change
Fixes #39 .

What the code does
The new classes KafkaWriterWorker and KafkaReaderWorker are added to kafka write, read and end to end latency bench marking.
Documentation about how to build and use the pravega benchmark tool for kafka bench marking is added.

How to verify it
build the tool;  use option "kafka -true" for Kafka bench marking with producers and consumers to write and read the events to/from Kafka cluster. Execute the end -end latency variant by supplying both producers and consumers.

Signed-off-by: Keshava Munegowda keshava.munegowda@dell.com