### PR TITLE
Closing Readergroups, writers and adding "-flush" parameter to Benchmark tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You may obtain a copy of the License at
 The Pravega benchmark tool used for the performance benchmarking of pravega streaming storage cluster.
 This tool performs the throughput and latency analysis for the multi producers/writers and consumers/readers of pravega.
 it also validates the end to end latency. The write and/or read latencies can be stored in a CSV file for later analysis.
-At the end of the performance benchmarking, this tool outputs the 50th, 75th, 95th , 99th and 99.9th latency percentiles.
+At the end of the performance benchmarking, this tool outputs the 50th, 75th, 95th , 99th, 99.9th and 99.99th latency percentiles.
 
 
 ### Prerequisites
@@ -42,7 +42,7 @@ untar the Pravega benchmark tool to local folder
 tar -xvf ./build/distributions/pravega-benchmark.tar -C ./run
 ```
 
-Running Pravega bencmark tool locally:
+Running Pravega benchmark tool locally:
 
 ```
 <dir>/pravega-benchmark$ ./run/pravega-benchmark/bin/pravega-benchmark  -help
@@ -87,8 +87,8 @@ The Pravega benchmark tool can be executed in the following modes:
 ```
 
 ### 1 - Burst Mode
-In this mode, the Pravega benchmark tool pushes/pulls the messages to/from the pravega client as much as possible.
-This mode is used to find the maximum and throughput that can be obtained from the pravega cluster.
+In this mode, the Pravega benchmark tool pushes/pulls the messages to/from the Pravega client as much as possible.
+This mode is used to find the maximum and throughput that can be obtained from the Pravega cluster.
 This mode can be used for both producers and consumers.
 
 ```
@@ -109,8 +109,8 @@ in the case you want to write/read the certain number of events use the -events 
 ```
 
 ### 2 - Throughput Mode
-In this mode, the Pravega benchmark tool pushes the messages to the pravega client with specified approximate maximum throughput in terms of Mega Bytes/second (MB/s).
-This mode is used to find the least latency that can be obtained from the pravega cluster for given throughput.
+In this mode, the Pravega benchmark tool pushes the messages to the Pravega client with specified approximate maximum throughput in terms of Mega Bytes/second (MB/s).
+This mode is used to find the least latency that can be obtained from the Pravega cluster for given throughput.
 This mode is used only for write operation.
 
 ```
@@ -135,8 +135,8 @@ in the case you want to write/read the certain number of events use the -events 
 
 ### 3 - OPS Mode or  Events Rate / Rate Limiter Mode
 This mode is another form of controlling writers throughput by limiting the number of events per second.
-In this mode, the Pravega benchmark tool pushes the messages to the pravega client with specified approximate maximum events per sec.
-This mode is used to find the least latency  that can be obtained from the pravega cluster for events rate.
+In this mode, the Pravega benchmark tool pushes the messages to the Pravega client with specified approximate maximum events per sec.
+This mode is used to find the least latency  that can be obtained from the Pravega cluster for events rate.
 This mode is used only for write operation.
 
 ```
@@ -152,7 +152,7 @@ Note that in this mode, there is 'NO total number of events' to specify hence us
 ```
 
 ### 4 - End to End Latency Mode
-In this mode, the Pravega benchmark tool writes and read the messages to the pravega cluster and records the end to end latency.
+In this mode, the Pravega benchmark tool writes and read the messages to the Pravega cluster and records the end to end latency.
 End to end latency means the time duration between the beginning of the writing event/record to stream and the time after reading the event/record.
 in this mode user must specify both the number of producers and consumers.
 The -throughput option (Throughput mode) or -events (late limiter) can used to limit the writers throughput or events rate.
@@ -166,5 +166,5 @@ The -throughput -1 specifies the writes tries to write the events at the maximum
 ```
 
 ### Recording the latencies to CSV files
-user can use the options "-writecsv  <file name>" to record the latencies of writers and "-readcsv <file name>" for readers.
+User can use the options "-writecsv  <file name>" to record the latencies of writers and "-readcsv <file name>" for readers.
 in case of End to End latency mode, if the user can supply only -readcsv to get the end to end latency in to the csv file.

--- a/README.md
+++ b/README.md
@@ -47,29 +47,31 @@ Running Pravega benchmark tool locally:
 ```
 <dir>/pravega-benchmark$ ./run/pravega-benchmark/bin/pravega-benchmark  -help
 usage: pravega-benchmark
- -consumers <arg>               number of consumers
- -controller <arg>              controller URI
- -events <arg>                  number of events/records if 'time' not
+ -consumers <arg>               Number of consumers
+ -controller <arg>              Controller URI
+ -events <arg>                  Number of events/records if 'time' not
                                 specified;
-                                otherwise, maximum events per second by
-                                producer(s) and/or number of events per
+                                otherwise, Maximum events per second by
+                                producer(s) and/or Number of events per
                                 consumer
+ -flush <arg>                   Number of events/records to flush per
+                                Producer;Not applicable, if both producers
+                                and consumers are specified
  -help                          Help message
- -producers <arg>               number of producers
- -readcsv <arg>                 csv file to record read latencies
+ -producers <arg>               Number of producers
+ -readcsv <arg>                 CSV file to record read latencies
  -recreate <arg>                If the stream is already existing, delete
-                                it and recreate it
+                                and recreate the same
  -segments <arg>                Number of segments
  -size <arg>                    Size of each message (event or record)
  -stream <arg>                  Stream name
  -throughput <arg>              if > 0 , throughput in MB/s
                                 if 0 , writes 'events'
                                 if -1, get the maximum throughput
- -time <arg>                    number of seconds the code runs
- -transaction <arg>             Producers use transactions or not
+ -time <arg>                    Number of seconds the code runs
  -transactionspercommit <arg>   Number of events before a transaction is
                                 committed
- -writecsv <arg>                csv file to record write latencies
+ -writecsv <arg>                CSV file to record write latencies
 ```
 
 ## Running Performance benchmarking

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ usage: pravega-benchmark
                                 otherwise, Maximum events per second by
                                 producer(s) and/or Number of events per
                                 consumer
- -flush <arg>                   Number of events/records to flush per
-                                Producer;Not applicable, if both producers
-                                and consumers are specified
+ -flush <arg>                   Each producer calls flush after writing
+                                <arg> number of of events/records; Not
+                                applicable, if both producers and
+                                consumers are specified
  -help                          Help message
  -producers <arg>               Number of producers
  -readcsv <arg>                 CSV file to record read latencies

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -94,7 +94,7 @@ public class PerfStats {
             final TimeWindow window = new TimeWindow(action, startTime);
             final LatencyWriter latencyRecorder = csvFile == null ? new LatencyWriter(action, messageSize, startTime) :
                     new CSVLatencyWriter(action, messageSize, startTime, csvFile);
-            final int minWaitTimeMS = windowInterval / 5;
+            final int minWaitTimeMS = windowInterval / 50;
             final long totalIdleCount = (NS_PER_MS / PARK_NS) * minWaitTimeMS;
             boolean doWork = true;
             long time = startTime;

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -80,6 +80,7 @@ public class PerfStats {
      * Private class for start and end time.
      */
     final private class QueueProcessor implements Callable {
+        final private static int PARK_NS = 1000;
         final private long startTime;
 
         private QueueProcessor(long startTime) {
@@ -106,7 +107,7 @@ public class PerfStats {
                     }
                     time = t.endTime;
                 } else {
-                    LockSupport.parkNanos(500);
+                    LockSupport.parkNanos(PARK_NS);
                     time = System.currentTimeMillis();
                 }
                 if (window.windowTimeMS(time) > windowInterval) {
@@ -188,7 +189,7 @@ public class PerfStats {
         final static int MS_PER_SEC = 1000;
         final static int MS_PER_MIN = MS_PER_SEC * 60;
         final static int MS_PER_HR = MS_PER_MIN * 60;
-        final double[] percentiles = {0.5, 0.75, 0.95, 0.99, 0.999};
+        final double[] percentiles = {0.5, 0.75, 0.95, 0.99, 0.999, 0.9999};
         final String action;
         final int messageSize;
         final long startTime;
@@ -255,6 +256,7 @@ public class PerfStats {
         }
 
         public void record(int bytes, int latency) {
+            assert latency < latencies.length : "Invalid latency";
             totalBytes += bytes;
             latencies[latency]++;
         }
@@ -272,9 +274,9 @@ public class PerfStats {
 
             System.out.printf(
                     "%d records %s, %.3f records/sec, %d bytes record size, %.2f MB/sec, %.1f ms avg latency, %.1f ms max latency" +
-                            ", %d ms 50th, %d ms 75th, %d ms 95th, %d ms 99th, %d ms 99.9th\n",
+                            ", %d ms 50th, %d ms 75th, %d ms 95th, %d ms 99th, %d ms 99.9th, %d ms 99.99th.\n",
                     count, action, recsPerSec, messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency,
-                    percs[0], percs[1], percs[2], percs[3], percs[4]);
+                    percs[0], percs[1], percs[2], percs[3], percs[4], percs[5]);
         }
     }
 

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -80,9 +80,12 @@ public class PerfStats {
      * Private class for start and end time.
      */
     final private class QueueProcessor implements Callable {
-        final private static int IDLE_COUNT = 1000;
         final private static int NS_PER_MICRO = 1000;
+        final private static int MICROS_PER_MS = 1000;
+        final private static int MINIMUM_WAIT_MS = 100;
+        final private static int NS_PER_MS = NS_PER_MICRO * MICROS_PER_MS;
         final private static int PARK_NS = NS_PER_MICRO;
+        final private static long IDLE_COUNT = (NS_PER_MS / PARK_NS) * MINIMUM_WAIT_MS;
         final private long startTime;
 
         private QueueProcessor(long startTime) {
@@ -95,7 +98,7 @@ public class PerfStats {
                     new CSVLatencyWriter(action, messageSize, startTime, csvFile);
             boolean doWork = true;
             long time = startTime;
-            int idleCount = 0;
+            long idleCount = 0;
             TimeStamp t;
 
             while (doWork) {

--- a/src/main/java/io/pravega/perf/Performance.java
+++ b/src/main/java/io/pravega/perf/Performance.java
@@ -13,8 +13,5 @@ package io.pravega.perf;
 import java.io.IOException;
 
 public interface Performance {
-    int TIME_HEADER_SIZE = 14;
-    String TIME_HEADER_FORMAT = "%0" + TIME_HEADER_SIZE + "d";
-
-    void benchmark() throws InterruptedException, IOException;
+     void benchmark() throws InterruptedException, IOException;
 }

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -181,7 +181,7 @@ public class PravegaPerfTest {
         final int eventsPerSec;
         final int eventsPerProducer;
         final int eventsPerConsumer;
-        final int flushEventsPerProducer;
+        final int EventsPerFlush;
         final int transactionPerCommit;
         final int runtimeSec;
         final double throughput;
@@ -220,12 +220,12 @@ public class PravegaPerfTest {
             if (commandline.hasOption("flush")) {
                 int flushEvents = Integer.parseInt(commandline.getOptionValue("flush"));
                 if (flushEvents > 0) {
-                    flushEventsPerProducer = flushEvents;
+                    EventsPerFlush = flushEvents;
                 } else {
-                    flushEventsPerProducer = Integer.MAX_VALUE;
+                    EventsPerFlush = Integer.MAX_VALUE;
                 }
             } else {
-                flushEventsPerProducer = Integer.MAX_VALUE;
+                EventsPerFlush = Integer.MAX_VALUE;
             }
 
             if (commandline.hasOption("time")) {
@@ -421,7 +421,7 @@ public class PravegaPerfTest {
                     writers = IntStream.range(0, producerCount)
                             .boxed()
                             .map(i -> new PravegaWriterWorker(i, eventsPerProducer,
-                                    flushEventsPerProducer, runtimeSec, false,
+                                    EventsPerFlush, runtimeSec, false,
                                     messageSize, startTime, produceStats,
                                     streamName, eventsPerSec, writeAndRead, factory))
                             .collect(Collectors.toList());

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -69,7 +69,7 @@ public class PravegaPerfTest {
                         "otherwise, Maximum events per second by producer(s) " +
                         "and/or Number of events per consumer");
         options.addOption("flush", true,
-                "Number of events/records to flush per Producer;" +
+                "Each producer calls flush after writing <arg> number of of events/records; " +
                         "Not applicable, if both producers and consumers are specified");
         options.addOption("time", true, "Number of seconds the code runs");
         options.addOption("transactionspercommit", true,

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -55,33 +55,35 @@ public class PravegaPerfTest {
         Option opt = null;
         final long startTime = System.currentTimeMillis();
 
-        opt = new Option("controller", true, "controller URI");
+        opt = new Option("controller", true, "Controller URI");
         opt.setRequired(true);
         options.addOption(opt);
         opt = new Option("stream", true, "Stream name");
         opt.setRequired(true);
         options.addOption(opt);
 
-        options.addOption("producers", true, "number of producers");
-        options.addOption("consumers", true, "number of consumers");
+        options.addOption("producers", true, "Number of producers");
+        options.addOption("consumers", true, "Number of consumers");
         options.addOption("events", true,
-                "number of events/records if 'time' not specified;\n" +
-                        "otherwise, maximum events per second by producer(s) " +
-                        "and/or number of events per consumer");
-        options.addOption("time", true, "number of seconds the code runs");
-        options.addOption("transaction", true, "Producers use transactions or not");
+                "Number of events/records if 'time' not specified;\n" +
+                        "otherwise, Maximum events per second by producer(s) " +
+                        "and/or Number of events per consumer");
+        options.addOption("flush", true,
+                "Number of events/records to flush per Producer;" +
+                        "Not applicable, if both producers and consumers are specified");
+        options.addOption("time", true, "Number of seconds the code runs");
         options.addOption("transactionspercommit", true,
                 "Number of events before a transaction is committed");
         options.addOption("segments", true, "Number of segments");
         options.addOption("size", true, "Size of each message (event or record)");
         options.addOption("recreate", true,
-                "If the stream is already existing, delete it and recreate it");
+                "If the stream is already existing, delete and recreate the same");
         options.addOption("throughput", true,
                 "if > 0 , throughput in MB/s\n" +
                         "if 0 , writes 'events'\n" +
                         "if -1, get the maximum throughput");
-        options.addOption("writecsv", true, "csv file to record write latencies");
-        options.addOption("readcsv", true, "csv file to record read latencies");
+        options.addOption("writecsv", true, "CSV file to record write latencies");
+        options.addOption("readcsv", true, "CSV file to record read latencies");
 
         options.addOption("help", false, "Help message");
 
@@ -110,7 +112,7 @@ public class PravegaPerfTest {
             final List<WriterWorker> producers = perfTest.getProducers();
             final List<ReaderWorker> consumers = perfTest.getConsumers();
 
-            final List<Callable<Void>> workers = Stream.of(producers, consumers)
+            final List<Callable<Void>> workers = Stream.of(consumers, producers)
                     .filter(x -> x != null)
                     .flatMap(x -> x.stream())
                     .collect(Collectors.toList());
@@ -184,6 +186,7 @@ public class PravegaPerfTest {
         final int eventsPerSec;
         final int eventsPerProducer;
         final int eventsPerConsumer;
+        final int flushEventsPerProducer;
         final int transactionPerCommit;
         final int runtimeSec;
         final double throughput;
@@ -217,6 +220,17 @@ public class PravegaPerfTest {
                 events = Integer.parseInt(commandline.getOptionValue("events"));
             } else {
                 events = 0;
+            }
+
+            if (commandline.hasOption("flush")) {
+                int flushEvents = Integer.parseInt(commandline.getOptionValue("flush"));
+                if (flushEvents > 0) {
+                    flushEventsPerProducer = flushEvents;
+                } else {
+                    flushEventsPerProducer = Integer.MAX_VALUE;
+                }
+            } else {
+                flushEventsPerProducer = Integer.MAX_VALUE;
             }
 
             if (commandline.hasOption("time")) {
@@ -291,6 +305,7 @@ public class PravegaPerfTest {
                 } else {
                     produceStats = new PerfStats("Writing", REPORTINGINTERVAL, messageSize, writeFile);
                 }
+
                 eventsPerProducer = (events + producerCount - 1) / producerCount;
                 if (throughput < 0 && runtimeSec > 0) {
                     eventsPerSec = events / producerCount;
@@ -319,7 +334,6 @@ public class PravegaPerfTest {
                 consumeStats = null;
                 eventsPerConsumer = 0;
             }
-
         }
 
         public void start(long startTime) throws IOException {
@@ -403,10 +417,9 @@ public class PravegaPerfTest {
                     writers = IntStream.range(0, producerCount)
                             .boxed()
                             .map(i -> new PravegaWriterWorker(i, eventsPerProducer,
-                                    runtimeSec, false,
-                                    messageSize, startTime,
-                                    produceStats, streamName,
-                                    eventsPerSec, writeAndRead, factory))
+                                    flushEventsPerProducer, runtimeSec, false,
+                                    messageSize, startTime, produceStats,
+                                    streamName, eventsPerSec, writeAndRead, factory))
                             .collect(Collectors.toList());
                 }
             } else {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -55,13 +55,8 @@ public class PravegaPerfTest {
         Option opt = null;
         final long startTime = System.currentTimeMillis();
 
-        opt = new Option("controller", true, "Controller URI");
-        opt.setRequired(true);
-        options.addOption(opt);
-        opt = new Option("stream", true, "Stream name");
-        opt.setRequired(true);
-        options.addOption(opt);
-
+        options.addOption("controller", true, "Controller URI");
+        options.addOption("stream", true, "Stream name");
         options.addOption("producers", true, "Number of producers");
         options.addOption("consumers", true, "Number of consumers");
         options.addOption("events", true,
@@ -289,6 +284,15 @@ public class PravegaPerfTest {
             }
 
             scopeName = SCOPE;
+
+            if (controllerUri == null) {
+                throw new IllegalArgumentException("Error: Must specify Controller IP address");
+            }
+
+            if (streamName == null) {
+                throw new IllegalArgumentException("Error: Must specify stream Name");
+            }
+
             if (producerCount == 0 && consumerCount == 0) {
                 throw new IllegalArgumentException("Error: Must specify the number of producers or Consumers");
             }

--- a/src/main/java/io/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamHandler.java
@@ -36,7 +36,7 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.Stream;
 
 /**
- *  Class for Pravega stream and segments.
+ * Class for Pravega stream and segments.
  */
 public class PravegaStreamHandler {
     final String scope;
@@ -134,14 +134,16 @@ public class PravegaStreamHandler {
         }
     }
 
-    ReaderGroup createReaderGroup() throws URISyntaxException {
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope,
-                ClientConfig.builder()
-                        .controllerURI(new URI(controllerUri)).build());
-        readerGroupManager.createReaderGroup(stream,
-                ReaderGroupConfig.builder()
-                        .stream(Stream.of(scope, stream))
-                        .build());
-        return readerGroupManager.getReaderGroup(stream);
+    ReaderGroup createReaderGroup(boolean reset) throws URISyntaxException {
+        final ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope,
+                ClientConfig.builder().controllerURI(new URI(controllerUri)).build());
+        final ReaderGroupConfig rdGrpConfig = ReaderGroupConfig.builder()
+                            .stream(Stream.of(scope, stream)).build();
+        readerGroupManager.createReaderGroup(stream, rdGrpConfig);
+        final ReaderGroup rdGroup = readerGroupManager.getReaderGroup(stream);
+        if (reset) {
+            rdGroup.resetReaderGroup(rdGrpConfig);
+        }
+        return rdGroup;
     }
 }

--- a/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
@@ -13,6 +13,7 @@ package io.pravega.perf;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.Transaction;
 import io.pravega.client.stream.TxnFailedException;
+
 import javax.annotation.concurrent.GuardedBy;
 
 public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
@@ -30,7 +31,7 @@ public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
                                    PerfStats stats, String streamName, int eventsPerSec, boolean writeAndRead,
                                    ClientFactory factory, int transactionsPerCommit) {
 
-        super(sensorId, events, secondsToRun, isRandomKey,
+        super(sensorId, events, Integer.MAX_VALUE, secondsToRun, isRandomKey,
                 messageSize, start, stats, streamName, eventsPerSec, writeAndRead, factory);
 
         this.transactionsPerCommit = transactionsPerCommit;

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -57,4 +57,9 @@ public class PravegaWriterWorker extends WriterWorker {
     public void flush() {
         producer.flush();
     }
+
+    @Override
+    public synchronized void close() {
+        producer.close();
+    }
 }

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -23,12 +23,12 @@ import io.pravega.client.stream.EventWriterConfig;
 public class PravegaWriterWorker extends WriterWorker {
     final EventStreamWriter<String> producer;
 
-    PravegaWriterWorker(int sensorId, int events, int flushEvents, int secondsToRun,
+    PravegaWriterWorker(int sensorId, int events, int EventsPerFlush, int secondsToRun,
                         boolean isRandomKey, int messageSize, long start,
                         PerfStats stats, String streamName, int eventsPerSec,
                         boolean writeAndRead, ClientFactory factory) {
 
-        super(sensorId, events, flushEvents,
+        super(sensorId, events, EventsPerFlush,
                 secondsToRun, isRandomKey, messageSize, start,
                 stats, streamName, eventsPerSec, writeAndRead);
 

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -23,13 +23,13 @@ import io.pravega.client.stream.EventWriterConfig;
 public class PravegaWriterWorker extends WriterWorker {
     final EventStreamWriter<String> producer;
 
-    PravegaWriterWorker(int sensorId, int events, int secondsToRun,
+    PravegaWriterWorker(int sensorId, int events, int flushEvents, int secondsToRun,
                         boolean isRandomKey, int messageSize, long start,
                         PerfStats stats, String streamName, int eventsPerSec,
                         boolean writeAndRead, ClientFactory factory) {
 
-        super(sensorId, events, secondsToRun,
-                isRandomKey, messageSize, start,
+        super(sensorId, events, flushEvents,
+                secondsToRun, isRandomKey, messageSize, start,
                 stats, streamName, eventsPerSec, writeAndRead);
 
         this.producer = factory.createEventWriter(streamName,

--- a/src/main/java/io/pravega/perf/ReaderWorker.java
+++ b/src/main/java/io/pravega/perf/ReaderWorker.java
@@ -52,11 +52,13 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
         public void benchmark() throws IOException {
             String ret = null;
             try {
-                for (int i = 0; i < events; i++) {
+                int i = 0;
+                while (i < events) {
                     final long startTime = System.currentTimeMillis();
                     ret = readData();
                     if (ret != null) {
                         stats.recordTime(startTime, System.currentTimeMillis(), ret.length());
+                        i++;
                     }
                 }
             } finally {
@@ -69,12 +71,14 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
         public void benchmark() throws IOException {
             String ret = null;
             try {
-                for (int i = 0; i < events; i++) {
+                int i = 0;
+                while (i < events) {
                     ret = readData();
                     if (ret != null) {
                         final long endTime = System.currentTimeMillis();
-                        final long startTime = Long.parseLong(ret.substring(0, TIME_HEADER_SIZE));
-                        stats.recordTime(startTime, endTime, ret.length());
+                        final long start = Long.parseLong(ret.substring(0, TIME_HEADER_SIZE));
+                        stats.recordTime(start, endTime, ret.length());
+                        i++;
                     }
                 }
             } finally {
@@ -91,7 +95,6 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
             long time = System.currentTimeMillis();
 
             try {
-
                 while ((time - startTime) < msToRun) {
                     time = System.currentTimeMillis();
                     ret = readData();
@@ -113,9 +116,9 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
             try {
                 while ((time - startTime) < msToRun) {
                     ret = readData();
+                    time = System.currentTimeMillis();
                     if (ret != null) {
-                        time = System.currentTimeMillis();
-                        final long startTime = Long.parseLong(ret.substring(0, TIME_HEADER_SIZE));
+                        final long start = Long.parseLong(ret.substring(0, TIME_HEADER_SIZE));
                         stats.recordTime(startTime, time, ret.length());
                     }
                 }

--- a/src/main/java/io/pravega/perf/ReaderWorker.java
+++ b/src/main/java/io/pravega/perf/ReaderWorker.java
@@ -23,8 +23,7 @@ public abstract class ReaderWorker extends Worker implements Callable<Void> {
 
     ReaderWorker(int readerId, int events, int secondsToRun, long start,
                  PerfStats stats, String readergrp, int timeout, boolean writeAndRead) {
-        super(readerId, events, secondsToRun,
-                0, start, stats, readergrp, timeout);
+        super(readerId, events, secondsToRun, 0, start, stats, readergrp, timeout);
 
         perf = secondsToRun > 0 ? (writeAndRead ? new EventsTimeReaderRW() : new EventsTimeReader()) :
                 (writeAndRead ? new EventsReaderRW() : new EventsReader());

--- a/src/main/java/io/pravega/perf/Worker.java
+++ b/src/main/java/io/pravega/perf/Worker.java
@@ -11,7 +11,7 @@
 package io.pravega.perf;
 
 /**
- *  Abstract class for Writers and Readers.
+ * Abstract class for Writers and Readers.
  */
 public abstract class Worker {
     final int workerID;

--- a/src/main/java/io/pravega/perf/Worker.java
+++ b/src/main/java/io/pravega/perf/Worker.java
@@ -14,6 +14,9 @@ package io.pravega.perf;
  * Abstract class for Writers and Readers.
  */
 public abstract class Worker {
+    final static int TIME_HEADER_SIZE = 14;
+    final static String TIME_HEADER_FORMAT = "%0" + TIME_HEADER_SIZE + "d";
+
     final int workerID;
     final int events;
     final int messageSize;

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -51,7 +51,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     /**
-     * Writes the data and benchmark
+     * Writes the data and benchmark.
      *
      * @param data   data to write
      * @param record to call for benchmarking
@@ -60,7 +60,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
     public abstract long recordWrite(String data, TriConsumer record);
 
     /**
-     * Writes the data and benchmark
+     * Writes the data and benchmark.
      *
      * @param data data to write
      */
@@ -70,6 +70,12 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
      * Flush the producer data.
      */
     public abstract void flush();
+
+    /**
+     * Flush the producer data.
+     */
+    public abstract void close();
+
 
     @Override
     public Void call() throws InterruptedException, ExecutionException, IOException {
@@ -101,9 +107,16 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
                 final String header = String.format(TIME_HEADER_FORMAT, System.currentTimeMillis());
                 final String data = buffer.replace(0, TIME_HEADER_SIZE, header).toString();
                 writeData(data);
+                /*
+                flush is required here for following reasons:
+                1. The writeData is called for End to End latency mode; hence make sure that data is sent.
+                2. In case of kafka benchmarking, the buffering makes too many writes;
+                   flushing moderates the kafka producer.
+                3. If the flush called after several iterations, then flush may take too much of time.
+                */
+                flush();
                 eCnt.control(i);
             }
-            flush();
         }
     }
 
@@ -136,9 +149,16 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
                 final String header = String.format(TIME_HEADER_FORMAT, time);
                 final String data = buffer.replace(0, TIME_HEADER_SIZE, header).toString();
                 writeData(data);
+                /*
+                flush is required here for following reasons:
+                1. The writeData is called for End to End latency mode; hence make sure that data is sent.
+                2. In case of kafka benchmarking, the buffering makes too many writes;
+                   flushing moderates the kafka producer.
+                3. If the flush called after several iterations, then flush may take too much of time.
+                */
+                flush();
                 eCnt.control(i);
             }
-            flush();
         }
     }
 

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -25,17 +25,18 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
     final private Performance perf;
     final private String payload;
     final private int eventsPerSec;
+    final private int flushEvents;
+    final private boolean writeAndRead;
 
-    WriterWorker(int sensorId, int events, int secondsToRun,
+    WriterWorker(int sensorId, int events, int flushEvents, int secondsToRun,
                  boolean isRandomKey, int messageSize, long start,
                  PerfStats stats, String streamName, int eventsPerSec, boolean writeAndRead) {
 
-        super(sensorId, events, secondsToRun,
-                messageSize, start, stats,
-                streamName, 0);
+        super(sensorId, events, secondsToRun, messageSize, start, stats, streamName, 0);
         this.eventsPerSec = eventsPerSec;
-        perf = secondsToRun > 0 ? (writeAndRead ? new EventsWriterTimeRW() : new EventsWriterTime()) :
-                (writeAndRead ? new EventsWriterRW() : new EventsWriter());
+        this.flushEvents = flushEvents;
+        this.writeAndRead = writeAndRead;
+        perf = createBenchmark();
         payload = createPayload(messageSize);
     }
 
@@ -47,6 +48,33 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
             bytes[i] = (byte) (random.nextInt(26) + 65);
         }
         return new String(bytes, StandardCharsets.US_ASCII);
+    }
+
+
+    private Performance createBenchmark() {
+        final Performance perfWriter;
+        if (secondsToRun > 0) {
+            if (writeAndRead) {
+                perfWriter = new EventsWriterTimeRW();
+            } else {
+                if (eventsPerSec > 0 || flushEvents < Integer.MAX_VALUE) {
+                    perfWriter = new EventsWriterTimeSleep();
+                } else {
+                    perfWriter = new EventsWriterTime();
+                }
+            }
+        } else {
+            if (writeAndRead) {
+                perfWriter = new EventsWriterRW();
+            } else {
+                if (eventsPerSec > 0 || flushEvents < Integer.MAX_VALUE) {
+                    perfWriter = new EventsWriterSleep();
+                } else {
+                    perfWriter = new EventsWriter();
+                }
+            }
+        }
+        return perfWriter;
     }
 
 
@@ -83,17 +111,66 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
         return null;
     }
 
+
     private class EventsWriter implements Performance {
 
         public void benchmark() throws InterruptedException, IOException {
-            final EventsController eCnt = new EventsController(System.currentTimeMillis(), eventsPerSec);
             for (int i = 0; i < events; i++) {
                 recordWrite(payload, stats::recordTime);
-                eCnt.control(i);
             }
             flush();
         }
     }
+
+
+    private class EventsWriterSleep implements Performance {
+
+        public void benchmark() throws InterruptedException, IOException {
+            final EventsController eCnt = new EventsController(System.currentTimeMillis(), eventsPerSec);
+            int cnt = 0;
+            while (cnt < events) {
+                int loopMax = Math.min(flushEvents, events - cnt);
+                for (int i = 0; i < loopMax; i++) {
+                    eCnt.control(cnt++, recordWrite(payload, stats::recordTime));
+                }
+                flush();
+            }
+        }
+    }
+
+
+    private class EventsWriterTime implements Performance {
+
+        public void benchmark() throws InterruptedException, IOException {
+            final long msToRun = secondsToRun * MS_PER_SEC;
+            long time = System.currentTimeMillis();
+            while ((time - startTime) < msToRun) {
+                time = recordWrite(payload, stats::recordTime);
+            }
+            flush();
+        }
+    }
+
+
+    private class EventsWriterTimeSleep implements Performance {
+
+        public void benchmark() throws InterruptedException, IOException {
+            final long msToRun = secondsToRun * MS_PER_SEC;
+            long time = System.currentTimeMillis();
+            final EventsController eCnt = new EventsController(time, eventsPerSec);
+            long msElapsed = time - startTime;
+            int cnt = 0;
+            while (msElapsed < msToRun) {
+                for (int i = 0; (msElapsed < msToRun) && (i < flushEvents); i++) {
+                    time = recordWrite(payload, stats::recordTime);
+                    eCnt.control(cnt++, time);
+                    msElapsed = time - startTime;
+                }
+                flush();
+            }
+        }
+    }
+
 
     private class EventsWriterRW implements Performance {
 
@@ -120,20 +197,6 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
         }
     }
 
-    private class EventsWriterTime implements Performance {
-
-        public void benchmark() throws InterruptedException, IOException {
-            final long msToRun = secondsToRun * MS_PER_SEC;
-            long time = System.currentTimeMillis();
-            final EventsController eCnt = new EventsController(time, eventsPerSec);
-
-            for (int i = 0; (time - startTime) < msToRun; i++) {
-                time = recordWrite(payload, stats::recordTime);
-                eCnt.control(i);
-            }
-            flush();
-        }
-    }
 
     private class EventsWriterTimeRW implements Performance {
 
@@ -163,7 +226,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
     }
 
     @NotThreadSafe
-    static private class EventsController {
+    final static private class EventsController {
         private static final long NS_PER_MS = 1000000L;
         private static final long NS_PER_SEC = 1000 * NS_PER_MS;
         private static final long MIN_SLEEP_NS = 2 * NS_PER_MS;
@@ -187,12 +250,28 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
          *
          * @param events current events
          */
-        private void control(long events) {
+        void control(long events) {
             if (this.eventsPerSec <= 0) {
                 return;
             }
+            needSleep(events, System.currentTimeMillis());
+        }
 
-            float elapsedSec = (System.currentTimeMillis() - startTime) / 1000.f;
+        /**
+         * Blocks for small amounts of time to achieve targetThroughput/events per sec
+         *
+         * @param events current events
+         * @param time   current time
+         */
+        void control(long events, long time) {
+            if (this.eventsPerSec <= 0) {
+                return;
+            }
+            needSleep(events, time);
+        }
+
+        private void needSleep(long events, long time) {
+            float elapsedSec = (time - startTime) / 1000.f;
 
             if ((events / elapsedSec) < this.eventsPerSec) {
                 return;


### PR DESCRIPTION
Change log description
Currently the reader groups are getting closed once the read compete; This  pull request ensures that reader groups and writers are closed even when the  user terminates the bench-marking.

Purpose of the change
Fixes #37, #41 , #43 

What the code does
To handle ctrl+c ,  the method to call closure of all readers and writer are invoked.
-flush <N>" parameter is added to the pravega benchmark tool.
where N is number of messages to flush per producer.
This option can be used to flush the message by producers while
measuring write performance.


How to verify it
build the tool and issue the writes with -flush <number of events> to verify the issue #41.
run the benchmark tool with consumers and press Ctrl+C while reading ; and re issue the same command to read the data from the beginning again.

Signed-off-by: Keshava Munegowda keshava.munegowda@dell.com