### PR TITLE
Issues 46 and 48: Add the "-scope" parameter and fix the reader-groups issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ usage: pravega-benchmark
  -readcsv <arg>                 CSV file to record read latencies
  -recreate <arg>                If the stream is already existing, delete
                                 and recreate the same
+ -scope <arg>                   Scope name
  -segments <arg>                Number of segments
  -size <arg>                    Size of each message (event or record)
  -stream <arg>                  Stream name

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -212,19 +212,7 @@ public class PerfStats {
         long totalLatency;
         long maxLatency;
         long totalBytes;
-        ArrayList<LatencyRange> latencyRanges;
-
-        private class LatencyRange {
-            private final int latency;
-            private final int start;
-            private final int end;
-
-            private LatencyRange(int latency, int start, int end) {
-                this.latency = latency;
-                this.start = start;
-                this.end = end;
-            }
-        }
+        ArrayList<int[]> latencyRanges;
 
         LatencyWriter(String action, int messageSize, long startTime) {
             this.action = action;
@@ -242,7 +230,7 @@ public class PerfStats {
             latencyRanges = new ArrayList<>();
             for (int i = 0, cur = 0; i < latencies.length; i++) {
                 if (latencies[i] > 0) {
-                    latencyRanges.add(new LatencyRange(i, cur, cur + latencies[i]));
+                    latencyRanges.add(new int[]{cur, cur + latencies[i], i});
                     cur += latencies[i] + 1;
                     totalLatency += i * latencies[i];
                     count += latencies[i];
@@ -260,10 +248,10 @@ public class PerfStats {
                 percentileIds[i] = (int) (count * percentiles[i]);
             }
 
-            for (LatencyRange lr : latencyRanges) {
+            for (int[] lr : latencyRanges) {
                 while ((index < percentileIds.length) &&
-                        (lr.start <= percentileIds[index]) && (percentileIds[index] <= lr.end)) {
-                    values[index++] = lr.latency;
+                        (lr[0] <= percentileIds[index]) && (percentileIds[index] <= lr[1])) {
+                    values[index++] = lr[2];
                 }
             }
             return values;

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -465,8 +465,8 @@ public class PravegaPerfTest {
         }
 
         @Override
-        public void closeReaderGroup(){
-            if (readerGroup != null){
+        public void closeReaderGroup() {
+            if (readerGroup != null) {
                 readerGroup.close();
             }
         }

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -56,6 +56,7 @@ public class PravegaPerfTest {
         final long startTime = System.currentTimeMillis();
 
         options.addOption("controller", true, "Controller URI");
+        options.addOption("scope", true, "Scope name");
         options.addOption("stream", true, "Stream name");
         options.addOption("producers", true, "Number of producers");
         options.addOption("consumers", true, "Number of consumers");
@@ -251,6 +252,12 @@ public class PravegaPerfTest {
                 streamName = null;
             }
 
+            if (commandline.hasOption("scope")) {
+                scopeName = commandline.getOptionValue("scope");
+            } else {
+                scopeName = SCOPE;
+            }
+
             if (commandline.hasOption("transactionspercommit")) {
                 transactionPerCommit = Integer.parseInt(commandline.getOptionValue("transactionspercommit"));
             } else {
@@ -297,7 +304,7 @@ public class PravegaPerfTest {
             if (producerCount == 0 && consumerCount == 0) {
                 throw new IllegalArgumentException("Error: Must specify the number of producers or Consumers");
             }
-            scopeName = SCOPE;
+
             if (recreate) {
                 rdGrpName = streamName + startTime;
             } else {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -308,7 +308,7 @@ public class PravegaPerfTest {
             if (recreate) {
                 rdGrpName = streamName + startTime;
             } else {
-                rdGrpName = streamName;
+                rdGrpName = streamName + "RdGrp";
             }
 
             if (producerCount > 0) {

--- a/src/main/java/io/pravega/perf/PravegaReaderWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaReaderWorker.java
@@ -12,7 +12,7 @@ package io.pravega.perf;
 
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.ClientFactory;
-import io.pravega.client.stream.impl.UTF8StringSerializer;
+import io.pravega.client.stream.impl.ByteArraySerializer;
 import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReinitializationRequiredException;
 
@@ -20,7 +20,7 @@ import io.pravega.client.stream.ReinitializationRequiredException;
  * Class for Pravega reader/consumer.
  */
 public class PravegaReaderWorker extends ReaderWorker {
-    private final EventStreamReader<String> reader;
+    private final EventStreamReader<byte[]> reader;
 
     PravegaReaderWorker(int readerId, int events, int secondsToRun,
                         long start, PerfStats stats, String readergrp,
@@ -29,11 +29,11 @@ public class PravegaReaderWorker extends ReaderWorker {
 
         final String readerSt = Integer.toString(readerId);
         reader = factory.createReader(
-                readerSt, readergrp, new UTF8StringSerializer(), ReaderConfig.builder().build());
+                readerSt, readergrp, new ByteArraySerializer(), ReaderConfig.builder().build());
     }
 
     @Override
-    public String readData() {
+    public byte[] readData() {
         try {
             return reader.readNextEvent(timeout).getEvent();
         } catch (ReinitializationRequiredException e) {

--- a/src/main/java/io/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamHandler.java
@@ -34,7 +34,6 @@ import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.InvalidStreamException;
 
 /**
  * Class for Pravega stream and segments.
@@ -158,8 +157,8 @@ public class PravegaStreamHandler {
     void deleteReaderGroup() {
         try {
             readerGroupManager.deleteReaderGroup(rdGrpName);
-        } catch (InvalidStreamException e) {
-            System.out.println("Reader Group is already deleted");
+        } catch (RuntimeException e) {
+            System.out.println("Cannot delete reader group " + rdGrpName + " because it is already deleted");
         }
     }
 }

--- a/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
@@ -23,7 +23,7 @@ public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
     private int eventCount;
 
     @GuardedBy("this")
-    private Transaction<String> transaction;
+    private Transaction<byte[]> transaction;
 
     PravegaTransactionWriterWorker(int sensorId, int events,
                                    int secondsToRun, boolean isRandomKey,
@@ -40,7 +40,7 @@ public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
     }
 
     @Override
-    public long recordWrite(String data, TriConsumer record) {
+    public long recordWrite(byte[] data, TriConsumer record) {
         long time = 0;
         try {
             synchronized (this) {

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -14,14 +14,14 @@ import java.util.concurrent.CompletableFuture;
 
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.ClientFactory;
-import io.pravega.client.stream.impl.UTF8StringSerializer;
+import io.pravega.client.stream.impl.ByteArraySerializer;
 import io.pravega.client.stream.EventWriterConfig;
 
 /**
  * Class for Pravega writer/producer.
  */
 public class PravegaWriterWorker extends WriterWorker {
-    final EventStreamWriter<String> producer;
+    final EventStreamWriter<byte[]> producer;
 
     PravegaWriterWorker(int sensorId, int events, int EventsPerFlush, int secondsToRun,
                         boolean isRandomKey, int messageSize, long start,
@@ -33,23 +33,23 @@ public class PravegaWriterWorker extends WriterWorker {
                 stats, streamName, eventsPerSec, writeAndRead);
 
         this.producer = factory.createEventWriter(streamName,
-                new UTF8StringSerializer(),
+                new ByteArraySerializer(),
                 EventWriterConfig.builder().build());
     }
 
     @Override
-    public long recordWrite(String data, TriConsumer record) {
+    public long recordWrite(byte[] data, TriConsumer record) {
         CompletableFuture ret;
         final long time = System.currentTimeMillis();
         ret = producer.writeEvent(data);
         ret.thenAccept(d -> {
-            record.accept(time, System.currentTimeMillis(), data.length());
+            record.accept(time, System.currentTimeMillis(), data.length);
         });
         return time;
     }
 
     @Override
-    public void writeData(String data) {
+    public void writeData(byte[] data) {
         producer.writeEvent(data);
     }
 

--- a/src/main/java/io/pravega/perf/Worker.java
+++ b/src/main/java/io/pravega/perf/Worker.java
@@ -14,8 +14,7 @@ package io.pravega.perf;
  * Abstract class for Writers and Readers.
  */
 public abstract class Worker {
-    final static int TIME_HEADER_SIZE = 14;
-    final static String TIME_HEADER_FORMAT = "%0" + TIME_HEADER_SIZE + "d";
+    final static int TIME_HEADER_SIZE = 8;
 
     final int workerID;
     final int events;


### PR DESCRIPTION
**Change log description**  
The "-scope"  parameter is added so that use the pass the name of the scope ; If no scope name is supplied then default scope name "Scope" is used. A different reader group names are used in case of end to end latency. 
The data format is changed from String to Byte Array to avoid the string serialization by Pravega.

**Purpose of the change**
Fixes #46, #48 

**What the code does**
By adding the "-scope" parameter , enabled the user to supply the custom scope names.
Currently reader group delete throws an error in-case of  reader group does not exists; hence different reader groups named used in case of end to end latency.

**How to verify it**
Tested the benchmark tool with and without "-scope" parameter.
Tested the end to end latency repeatedly on bare metal setup and standalone execution.