### PR TITLE
Issue 54: Use Pravega Client version 0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ buildscript {
 
     dependencies {
 
-        compile "io.pravega:pravega-client:0.4.0",
-                "io.pravega:pravega-common:0.4.0",
+        compile "io.pravega:pravega-client:0.5.0",
+                "io.pravega:pravega-common:0.5.0",
                 "commons-cli:commons-cli:1.3.1",
                 "org.apache.commons:commons-csv:1.5"
 


### PR DESCRIPTION
**Change log description**  
The pravega benchmark tool uses the pravega client version 0.5

**Purpose of the change**  
Fixes #54 

**What the code does**  
The build.gradle is updated to use the Pravega client version 0.5

Signed-off-by: Keshava Munegowda <keshava.munegowda@dell.com>