### PR TITLE
Issue 57: Add "-fork" option

### DIFF
--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.LockSupport;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -38,7 +39,7 @@ public class PerfStats {
     final private int messageSize;
     final private int windowInterval;
     final private ConcurrentLinkedQueue<TimeStamp> queue;
-    final private ForkJoinPool executor;
+    final private ExecutorService executor;
 
     @GuardedBy("this")
     private Future<Void> ret;

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -352,7 +352,6 @@ public class PerfStats {
         if (this.ret != null) {
             queue.add(new TimeStamp(endTime));
             ret.get();
-            executor.shutdownNow();
             queue.clear();
             this.ret = null;
         }

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -67,13 +67,13 @@ public class PerfStats {
         }
     }
 
-    public PerfStats(String action, int reportingInterval, int messageSize, String csvFile) {
+    public PerfStats(String action, int reportingInterval, int messageSize, String csvFile, ExecutorService executor) {
         this.action = action;
         this.messageSize = messageSize;
         this.windowInterval = reportingInterval;
         this.csvFile = csvFile;
+        this.executor = executor;
         this.queue = new ConcurrentLinkedQueue<>();
-        this.executor = new ForkJoinPool(1);
         this.ret = null;
     }
 

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ExecutorService;

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -284,7 +284,7 @@ public class PravegaPerfTest {
             if (commandline.hasOption("fork")) {
                 fork = Boolean.parseBoolean(commandline.getOptionValue("fork"));
             } else {
-                fork = false;
+                fork = true;
             }
 
             if (commandline.hasOption("throughput")) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -321,7 +321,7 @@ public class PravegaPerfTest {
             if (fork) {
                 executor = new ForkJoinPool(threadCount);
             } else {
-                executor = Executors.newScheduledThreadPool(threadCount);
+                executor = Executors.newFixedThreadPool(threadCount);
             }
 
             if (recreate) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Performance benchmark for Pravega.
@@ -102,7 +103,7 @@ public class PravegaPerfTest {
             System.exit(0);
         }
 
-        final ForkJoinPool executor = new ForkJoinPool();
+        final ExecutorService executor = new ForkJoinPool();
 
         try {
             final List<WriterWorker> producers = perfTest.getProducers();

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -202,37 +202,32 @@ public class PravegaPerfTest {
 
         Test(long startTime, CommandLine commandline) throws IllegalArgumentException {
             this.startTime = startTime;
-            if (commandline.hasOption("controller")) {
-                controllerUri = commandline.getOptionValue("controller");
-            } else {
-                controllerUri = null;
+            controllerUri = commandline.getOptionValue("controller", null);
+            streamName = commandline.getOptionValue("stream", null);
+            producerCount = Integer.parseInt(commandline.getOptionValue("producers", "0"));
+            consumerCount = Integer.parseInt(commandline.getOptionValue("consumers", "0"));
+
+            if (controllerUri == null) {
+                throw new IllegalArgumentException("Error: Must specify Controller IP address");
             }
 
-            if (commandline.hasOption("producers")) {
-                producerCount = Integer.parseInt(commandline.getOptionValue("producers"));
-            } else {
-                producerCount = 0;
+            if (streamName == null) {
+                throw new IllegalArgumentException("Error: Must specify stream Name");
             }
 
-            if (commandline.hasOption("consumers")) {
-                consumerCount = Integer.parseInt(commandline.getOptionValue("consumers"));
-            } else {
-                consumerCount = 0;
+            if (producerCount == 0 && consumerCount == 0) {
+                throw new IllegalArgumentException("Error: Must specify the number of producers or Consumers");
             }
-
-            if (commandline.hasOption("events")) {
-                events = Integer.parseInt(commandline.getOptionValue("events"));
-            } else {
-                events = 0;
-            }
-
-            if (commandline.hasOption("flush")) {
-                int flushEvents = Integer.parseInt(commandline.getOptionValue("flush"));
-                if (flushEvents > 0) {
-                    EventsPerFlush = flushEvents;
-                } else {
-                    EventsPerFlush = Integer.MAX_VALUE;
-                }
+            events = Integer.parseInt(commandline.getOptionValue("events", "0"));
+            messageSize = Integer.parseInt(commandline.getOptionValue("size","0"));
+            scopeName = commandline.getOptionValue("scope",SCOPE);
+            transactionPerCommit = Integer.parseInt(commandline.getOptionValue("transactionspercommit","0"));
+            fork = Boolean.parseBoolean(commandline.getOptionValue("fork", "true"));
+            writeFile = commandline.getOptionValue("writecsv",null);
+            readFile = commandline.getOptionValue("readcsv", null);
+            int flushEvents = Integer.parseInt(commandline.getOptionValue("flush", "0"));
+            if (flushEvents > 0) {
+                EventsPerFlush = flushEvents;
             } else {
                 EventsPerFlush = Integer.MAX_VALUE;
             }
@@ -243,30 +238,6 @@ public class PravegaPerfTest {
                 runtimeSec = 0;
             } else {
                 runtimeSec = MAXTIME;
-            }
-
-            if (commandline.hasOption("size")) {
-                messageSize = Integer.parseInt(commandline.getOptionValue("size"));
-            } else {
-                messageSize = 0;
-            }
-
-            if (commandline.hasOption("stream")) {
-                streamName = commandline.getOptionValue("stream");
-            } else {
-                streamName = null;
-            }
-
-            if (commandline.hasOption("scope")) {
-                scopeName = commandline.getOptionValue("scope");
-            } else {
-                scopeName = SCOPE;
-            }
-
-            if (commandline.hasOption("transactionspercommit")) {
-                transactionPerCommit = Integer.parseInt(commandline.getOptionValue("transactionspercommit"));
-            } else {
-                transactionPerCommit = 0;
             }
 
             if (commandline.hasOption("segments")) {
@@ -281,43 +252,12 @@ public class PravegaPerfTest {
                 recreate = producerCount > 0 && consumerCount > 0;
             }
 
-            if (commandline.hasOption("fork")) {
-                fork = Boolean.parseBoolean(commandline.getOptionValue("fork"));
-            } else {
-                fork = true;
-            }
-
             if (commandline.hasOption("throughput")) {
                 throughput = Double.parseDouble(commandline.getOptionValue("throughput"));
             } else {
                 throughput = -1;
             }
-
-            if (commandline.hasOption("writecsv")) {
-                writeFile = commandline.getOptionValue("writecsv");
-            } else {
-                writeFile = null;
-            }
-            if (commandline.hasOption("readcsv")) {
-                readFile = commandline.getOptionValue("readcsv");
-            } else {
-                readFile = null;
-            }
-
-            if (controllerUri == null) {
-                throw new IllegalArgumentException("Error: Must specify Controller IP address");
-            }
-
-            if (streamName == null) {
-                throw new IllegalArgumentException("Error: Must specify stream Name");
-            }
-
-            if (producerCount == 0 && consumerCount == 0) {
-                throw new IllegalArgumentException("Error: Must specify the number of producers or Consumers");
-            }
-
             final int threadCount = producerCount + consumerCount + 6;
-
             if (fork) {
                 executor = new ForkJoinPool(threadCount);
             } else {

--- a/src/main/java/io/pravega/perf/ReaderWorker.java
+++ b/src/main/java/io/pravega/perf/ReaderWorker.java
@@ -12,7 +12,6 @@ package io.pravega.perf;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -194,7 +194,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
         for (int i = 0; (time - startTime) < msToRun; i++) {
             time = System.currentTimeMillis();
-            byte[] bytes = timeBuffer.putLong(0, System.currentTimeMillis()).array();
+            byte[] bytes = timeBuffer.putLong(0, time).array();
             System.arraycopy(bytes, 0, payload, 0, bytes.length);
             writeData(payload);
                 /*


### PR DESCRIPTION
**Change log description**  
A new option "-fork" option is added; by default it is set o True; if it set to false, then new fixed thread pool is used.

**Purpose of the change**  
Fixes #57 

**What the code does**  
when user supplies -fork false; conventional thread pool is used; otherwise fork join pool is used.

Signed-off-by: Keshava Munegowda <keshava.munegowda@dell.com>