### PR TITLE
Issue 56 track unacked; added option to disable connection pooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gradle
+.idea
+build
+out

--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,16 @@ build
 .classpath
 .DS_Store
 bin/
+ca-certificates/
+!ca-certificates/README.txt
 classes/
 .settings
 .gradle
 output
 .idea
 target
+lib/
+!lib/README.txt
 log/
 out/
 .metadata/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Building Container
+
+FROM gradle:4.10-jdk8 as GradleBuilder
+
+USER 0
+
+COPY ca-certificates/* /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+RUN apt-get update \
+    && apt-get install -y \
+        maven \
+    && rm -rf /var/lib/apt/lists/*
+
+USER gradle
+
+COPY --chown=gradle:gradle build.gradle /home/gradle/src/build.gradle
+COPY --chown=gradle:gradle gradle /home/gradle/src/gradle
+COPY --chown=gradle:gradle gradle.properties /home/gradle/src/gradle.properties
+COPY --chown=gradle:gradle settings.gradle /home/gradle/src/settings.gradle
+COPY --chown=gradle:gradle lib /home/gradle/src/lib
+COPY --chown=gradle:gradle src /home/gradle/src/src
+
+WORKDIR /home/gradle/src
+
+ENV GRADLE_USER_HOME=/home/gradle
+ENV CREDENTIALS_VERSION=0.5.0-2306.a5a5cdf-0.11.10-002.985e705
+
+RUN mvn install:install-file \
+-Dfile=lib/pravega-keycloak-credentials-${CREDENTIALS_VERSION}-shadow.jar \
+-DgroupId=io.pravega \
+-DartifactId=pravega-keycloak-credentials \
+-Dversion=${CREDENTIALS_VERSION} -Dpackaging=jar
+
+RUN gradle installDist \
+--no-daemon --info --stacktrace \
+-PincludePravegaCredentials=true \
+-PpravegaCredentialsVersion=${CREDENTIALS_VERSION}
+
+# Runtime Container
+
+FROM openjdk:8-jre
+
+ENV APP_NAME=pravega-benchmark
+
+COPY --from=GradleBuilder /home/gradle/src/build/install/${APP_NAME} /opt/${APP_NAME}
+
+ENTRYPOINT ["/opt/pravega-benchmark/bin/pravega-benchmark"]

--- a/build.gradle
+++ b/build.gradle
@@ -13,29 +13,27 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'application'
 
+mainClassName = "io.pravega.perf.PravegaPerfTest"
 
-buildscript {
-    repositories {
-        jcenter()
-    }
+repositories {
+    jcenter()
+    mavenLocal()
+    mavenCentral()
 }
 
-    repositories {
-        mavenLocal()
-        jcenter()
-        mavenCentral()
+dependencies {
+    compile "io.pravega:pravega-client:${pravegaVersion}",
+            "io.pravega:pravega-common:${pravegaVersion}",
+            "commons-cli:commons-cli:${commonsCLIVersion}",
+            "org.apache.commons:commons-csv:1.5"
+
+    if (includePravegaCredentials.toBoolean()) {
+        compile "io.pravega:pravega-keycloak-credentials:${pravegaCredentialsVersion}"
     }
 
-    dependencies {
+    runtime "org.slf4j:slf4j-simple:1.7.14"
+}
 
-        compile "io.pravega:pravega-client:0.5.0",
-                "io.pravega:pravega-common:0.5.0",
-                "commons-cli:commons-cli:1.3.1",
-                "org.apache.commons:commons-csv:1.5"
-
-        runtime "org.slf4j:slf4j-simple:1.7.14"
-    }
-mainClassName = "io.pravega.perf.PravegaPerfTest"
 startScripts {
     doLast {
         unixScript.text = unixScript.text.replace('SERVER_APP_HOME', '\$APP_HOME')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+commonsCLIVersion=1.3.1
+pravegaCredentialsVersion=0.5.0-2306.a5a5cdf-0.11.10-002.985e705
+pravegaVersion=0.5.0
+
+# Set below to true when using Pravega in Nautilus.
+includePravegaCredentials=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Sep 04 14:34:44 UTC 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+set -ex
+
+: ${DOCKER_REPOSITORY?"You must export DOCKER_REPOSITORY"}
+: ${IMAGE_TAG?"You must export IMAGE_TAG"}
+
+ROOT_DIR=$(dirname $0)/..
+
+docker build -f ${ROOT_DIR}/Dockerfile ${ROOT_DIR} --tag ${DOCKER_REPOSITORY}/pravega-benchmark:${IMAGE_TAG}
+
+docker push ${DOCKER_REPOSITORY}/pravega-benchmark:${IMAGE_TAG}

--- a/scripts/pravega-benchmark-k8s.sh
+++ b/scripts/pravega-benchmark-k8s.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+kubectl delete -f pravega-benchmark.yaml -n examples
+kubectl apply -f pravega-benchmark.yaml -n examples
+sleep 5s
+kubectl logs -f jobs/pravega-benchmark -n examples

--- a/scripts/pravega-benchmark-k8s.sh
+++ b/scripts/pravega-benchmark-k8s.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-kubectl delete -f pravega-benchmark.yaml -n examples
-kubectl apply -f pravega-benchmark.yaml -n examples
+NAMESPACE=${NAMESPACE:-examples}
+kubectl delete -f pravega-benchmark.yaml -n ${NAMESPACE}
+kubectl apply -f pravega-benchmark.yaml -n ${NAMESPACE}
 sleep 5s
-kubectl logs -f jobs/pravega-benchmark -n examples
+kubectl logs -f jobs/pravega-benchmark -n ${NAMESPACE}

--- a/scripts/pravega-benchmark.yaml
+++ b/scripts/pravega-benchmark.yaml
@@ -1,0 +1,39 @@
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: pravega-benchmark
+spec:
+  parallelism: 3
+  template:
+    spec:
+      serviceAccount: examples-pravega
+      restartPolicy: Never
+      containers:
+        - name: benchmark
+          image: claudiofahey/pravega-benchmark:0.5.0
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+            requests:
+              cpu: "1"
+              memory: "4Gi"
+          args: [
+            "-controller", "tcp://nautilus-pravega-controller.nautilus-pravega.svc.cluster.local:9090",
+            "-scope", "examples",
+            "-stream", "benchmark5",
+            #"-recreate", "1",
+            "-segments", "96",
+            "-producers", "1",
+            "-time", "3600",  # Number of seconds to run
+            "-size", "524288",
+#            "-throughput", "30",
+          ]
+          env:
+            - name: JAVA_OPTS
+              value: "-Xmx2g -Xms1g"
+            - name: pravega_client_auth_method
+              value: Bearer
+            - name: pravega_client_auth_loadDynamic
+              value: "true"

--- a/scripts/pravega-benchmark.yaml
+++ b/scripts/pravega-benchmark.yaml
@@ -6,7 +6,7 @@ spec:
   parallelism: 3
   template:
     spec:
-      serviceAccount: examples-pravega
+      serviceAccount: examples3-pravega
       restartPolicy: Never
       containers:
         - name: benchmark
@@ -21,14 +21,15 @@ spec:
               memory: "4Gi"
           args: [
             "-controller", "tcp://nautilus-pravega-controller.nautilus-pravega.svc.cluster.local:9090",
-            "-scope", "examples",
+            "-scope", "examples3",
             "-stream", "benchmark5",
             #"-recreate", "1",
             "-segments", "96",
             "-producers", "1",
             "-time", "3600",  # Number of seconds to run
             "-size", "524288",
-#            "-throughput", "30",
+            "-throughput", "30",
+            "-enableConnectionPooling", "false",
           ]
           env:
             - name: JAVA_OPTS

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -24,6 +24,8 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -33,6 +35,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  * Class for Performance statistics.
  */
 public class PerfStats {
+    private static Logger log = LoggerFactory.getLogger(PerfStats.class);
+
     final private String action;
     final private String csvFile;
     final private int messageSize;
@@ -124,11 +128,10 @@ public class PerfStats {
                         }
                         time = t.endTime;
                         if (window.windowTimeMS(time) > windowInterval) {
-                            window.print(time);
-                            window.reset(time);
                             double unAckedMiB = (sentBytes - ackedBytes) / 1024.0 / 1024.0;
                             long unAckedEvents = sentEvents - ackedEvents;
-                            System.out.printf("%.3f MiB in %d events unacked", unAckedMiB, unAckedEvents);
+                            log.info(String.format("%s, %.3f MiB in %d events unacked", window.toString(time), unAckedMiB, unAckedEvents));
+                            window.reset(time);
                         }
                     } else {
                         sentEvents++;
@@ -141,7 +144,7 @@ public class PerfStats {
                         time = System.currentTimeMillis();
                         idleCount = 0;
                         if (window.windowTimeMS(time) > windowInterval) {
-                            window.print(time);
+                            log.info(window.toString(time));
                             window.reset(time);
                         }
                     }
@@ -193,16 +196,18 @@ public class PerfStats {
         }
 
         /**
-         * Print the window statistics
+         * Get the window statistics as a string
+         *
+         * Note that record and byte counters are for acked events.
          */
-        private void print(long time) {
+        private String toString(long time) {
             this.lastTime = time;
             assert this.lastTime > this.startTime : "Invalid Start and EndTime";
             final double elapsed = (this.lastTime - this.startTime) / 1000.0;
             final double recsPerSec = count / elapsed;
             final double mbPerSec = (this.bytes / (1024.0 * 1024.0)) / elapsed;
 
-            System.out.printf("%8d records %s, %9.1f records/sec, %6.2f MiB/sec, %7.1f ms avg latency, %7.1f ms max latency\n",
+            return String.format("%8d records %s, %9.1f records/sec, %6.2f MiB/sec, %7.1f ms avg latency, %7.1f ms max latency",
                     count, action, recsPerSec, mbPerSec, totalLatency / (double) count, (double) maxLatency);
         }
 
@@ -292,11 +297,11 @@ public class PerfStats {
             final double mbPerSec = (this.totalBytes / (1024.0 * 1024.0)) / elapsed;
             int[] percs = getPercentiles();
 
-            System.out.printf(
+            log.info(String.format(
                     "%d records %s, %.3f records/sec, %d bytes record size, %.2f MB/sec, %.1f ms avg latency, %.1f ms max latency" +
                             ", %d ms 50th, %d ms 75th, %d ms 95th, %d ms 99th, %d ms 99.9th, %d ms 99.99th.\n",
                     count, action, recsPerSec, messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency,
-                    percs[0], percs[1], percs[2], percs[3], percs[4], percs[5]);
+                    percs[0], percs[1], percs[2], percs[3], percs[4], percs[5]));
         }
     }
 

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -80,6 +80,7 @@ public class PravegaPerfTest {
                         "if -1, get the maximum throughput");
         options.addOption("writecsv", true, "CSV file to record write latencies");
         options.addOption("readcsv", true, "CSV file to record read latencies");
+        options.addOption("enableConnectionPooling", true, "enable connection pooling");
 
         options.addOption("help", false, "Help message");
 
@@ -194,6 +195,7 @@ public class PravegaPerfTest {
         final PerfStats produceStats;
         final PerfStats consumeStats;
         final long startTime;
+        final boolean enableConnectionPooling;
 
         Test(long startTime, CommandLine commandline) throws IllegalArgumentException {
             this.startTime = startTime;
@@ -292,6 +294,8 @@ public class PravegaPerfTest {
             } else {
                 readFile = null;
             }
+
+            enableConnectionPooling = Boolean.parseBoolean(commandline.getOptionValue("enableConnectionPooling", "true"));
 
             if (controllerUri == null) {
                 throw new IllegalArgumentException("Error: Must specify Controller IP address");
@@ -431,7 +435,7 @@ public class PravegaPerfTest {
                                     messageSize, startTime,
                                     produceStats, streamName,
                                     eventsPerSec, writeAndRead, factory,
-                                    transactionPerCommit))
+                                    transactionPerCommit, enableConnectionPooling))
                             .collect(Collectors.toList());
                 } else {
                     writers = IntStream.range(0, producerCount)
@@ -439,7 +443,7 @@ public class PravegaPerfTest {
                             .map(i -> new PravegaWriterWorker(i, eventsPerProducer,
                                     EventsPerFlush, runtimeSec, false,
                                     messageSize, startTime, produceStats,
-                                    streamName, eventsPerSec, writeAndRead, factory))
+                                    streamName, eventsPerSec, writeAndRead, factory, enableConnectionPooling))
                             .collect(Collectors.toList());
                 }
             } else {

--- a/src/main/java/io/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamHandler.java
@@ -66,7 +66,6 @@ public class PravegaStreamHandler {
         this.timeout = timeout;
         this.bgexecutor = bgexecutor;
         streamManager = StreamManager.create(new URI(uri));
-        streamManager.createScope(scope);
         streamconfig = StreamConfiguration.builder().scope(scope).streamName(stream)
                 .scalingPolicy(ScalingPolicy.fixed(segCount))
                 .build();

--- a/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
@@ -29,10 +29,10 @@ public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
                                    int secondsToRun, boolean isRandomKey,
                                    int messageSize, long start,
                                    PerfStats stats, String streamName, int eventsPerSec, boolean writeAndRead,
-                                   ClientFactory factory, int transactionsPerCommit) {
+                                   ClientFactory factory, int transactionsPerCommit, boolean enableConnectionPooling) {
 
         super(sensorId, events, Integer.MAX_VALUE, secondsToRun, isRandomKey,
-                messageSize, start, stats, streamName, eventsPerSec, writeAndRead, factory);
+                messageSize, start, stats, streamName, eventsPerSec, writeAndRead, factory, enableConnectionPooling);
 
         this.transactionsPerCommit = transactionsPerCommit;
         eventCount = 0;

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -16,25 +16,34 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.impl.ByteArraySerializer;
 import io.pravega.client.stream.EventWriterConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class for Pravega writer/producer.
  */
 public class PravegaWriterWorker extends WriterWorker {
+    private static Logger log = LoggerFactory.getLogger(PravegaWriterWorker.class);
+
     final EventStreamWriter<byte[]> producer;
 
     PravegaWriterWorker(int sensorId, int events, int EventsPerFlush, int secondsToRun,
                         boolean isRandomKey, int messageSize, long start,
                         PerfStats stats, String streamName, int eventsPerSec,
-                        boolean writeAndRead, ClientFactory factory) {
+                        boolean writeAndRead, ClientFactory factory,
+                        boolean enableConnectionPooling) {
 
         super(sensorId, events, EventsPerFlush,
                 secondsToRun, isRandomKey, messageSize, start,
                 stats, streamName, eventsPerSec, writeAndRead);
 
+        log.info("enableConnectionPooling={}", enableConnectionPooling);
+
         this.producer = factory.createEventWriter(streamName,
                 new ByteArraySerializer(),
-                EventWriterConfig.builder().build());
+                EventWriterConfig.builder()
+                        .enableConnectionPooling(enableConnectionPooling)
+                        .build());
     }
 
     @Override

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -41,6 +41,7 @@ public class PravegaWriterWorker extends WriterWorker {
     public long recordWrite(byte[] data, TriConsumer record) {
         CompletableFuture ret;
         final long time = System.currentTimeMillis();
+        record.accept(time, -1, data.length);
         ret = producer.writeEvent(data);
         ret.thenAccept(d -> {
             record.accept(time, System.currentTimeMillis(), data.length);

--- a/src/main/java/io/pravega/perf/TriConsumer.java
+++ b/src/main/java/io/pravega/perf/TriConsumer.java
@@ -11,5 +11,5 @@
 package io.pravega.perf;
 
 public interface TriConsumer {
-    void accept(long a, long b, int c);
+    void accept(long startTime, long endTime, int bytes);
 }

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -79,7 +79,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     /**
-     * Writes the data and benchmark.
+     * Writes the data and records statistics.
      *
      * @param data   data to write
      * @param record to call for benchmarking
@@ -88,7 +88,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
     public abstract long recordWrite(byte[] data, TriConsumer record);
 
     /**
-     * Writes the data and benchmark.
+     * Writes the data. Does not record statistics.
      *
      * @param data data to write
      */

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,34 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+#org.slf4j.simpleLogger.showDateTime=false
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+#org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the last component of the name to be included in output messages.
+# Defaults to false.
+#org.slf4j.simpleLogger.showShortLogName=false

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -13,13 +13,13 @@ org.slf4j.simpleLogger.defaultLogLevel=info
 
 # Set to true if you want the current date and time to be included in output messages.
 # Default is false, and will output the number of milliseconds elapsed since startup.
-#org.slf4j.simpleLogger.showDateTime=false
+org.slf4j.simpleLogger.showDateTime=true
 
 # The date and time format to be used in the output messages.
 # The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
 # If the format is not specified or is invalid, the default format is used.
 # The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
-#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
 
 # Set to true if you want to output the current thread name.
 # Defaults to true.


### PR DESCRIPTION
This PR includes various unrelated updates. Let me know if you need these as separate issues, branches, and PRs.

- Number of unacked events and bytes are now periodically printed
- Added Dockerfile and Kubernetes job
- Removed createScope to allow this to run in Nautilus
- Added option to disable connection pooling for producers
- Statistics are now logged using the slf4j logger so that timestamps are printed