### PR TITLE
Issue 57 7 & 60: Add "-fork " and "-kafka" options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,8 @@ buildscript {
         compile "io.pravega:pravega-client:0.5.0",
                 "io.pravega:pravega-common:0.5.0",
                 "commons-cli:commons-cli:1.3.1",
-                "org.apache.commons:commons-csv:1.5"
+                "org.apache.commons:commons-csv:1.5",
+                "org.apache.kafka:kafka-clients:2.2.0"
 
         runtime "org.slf4j:slf4j-simple:1.7.14"
     }

--- a/src/main/java/io/pravega/perf/KafkaReaderWorker.java
+++ b/src/main/java/io/pravega/perf/KafkaReaderWorker.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.perf;
+
+import java.util.Properties;
+import java.util.Arrays;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+/**
+ * Class for Kafka reader/consumer.
+ */
+public class KafkaReaderWorker extends ReaderWorker {
+    final private KafkaConsumer<byte[], byte[]> consumer;
+
+    KafkaReaderWorker(int readerId, int events, int secondsToRun,
+                      long start, PerfStats stats, String partition,
+                      int timeout, boolean writeAndRead, Properties consumerProps) {
+        super(readerId, events, secondsToRun, start, stats, partition, timeout, writeAndRead);
+
+        this.consumer = new KafkaConsumer<>(consumerProps);
+        this.consumer.subscribe(Arrays.asList(partition));
+    }
+
+    @Override
+    public byte[] readData() {
+        final ConsumerRecords<byte[], byte[]> records = consumer.poll(timeout);
+        if (records.isEmpty()) {
+            return null;
+        }
+        return records.iterator().next().value();
+    }
+
+    @Override
+    public void close() {
+        consumer.close();
+    }
+}

--- a/src/main/java/io/pravega/perf/KafkaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/KafkaWriterWorker.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.perf;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+/**
+ * Class for Kafka writer/producer.
+ */
+public class KafkaWriterWorker extends WriterWorker {
+    final private KafkaProducer<byte[], byte[]> producer;
+
+    KafkaWriterWorker(int sensorId, int events, int flushEvents,
+                      int secondsToRun, boolean isRandomKey, int messageSize,
+                      long start, PerfStats stats, String streamName,
+                      int eventsPerSec, boolean writeAndRead, Properties producerProps) {
+
+        super(sensorId, events, flushEvents,
+                secondsToRun, isRandomKey, messageSize,
+                start, stats, streamName, eventsPerSec, writeAndRead);
+
+        this.producer = new KafkaProducer<>(producerProps);
+    }
+
+    public long recordWrite(byte[] data, TriConsumer record) {
+        final long time = System.currentTimeMillis();
+        producer.send(new ProducerRecord<>(streamName, data), (metadata, exception) -> {
+            record.accept(time, System.currentTimeMillis(), data.length);
+        });
+        return time;
+    }
+
+    @Override
+    public void writeData(byte[] data) {
+        producer.send(new ProducerRecord<>(streamName, data));
+    }
+
+
+    @Override
+    public void flush() {
+        producer.flush();
+    }
+
+    @Override
+    public synchronized void close() {
+        producer.close();
+    }
+}

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.LockSupport;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -38,7 +39,7 @@ public class PerfStats {
     final private int messageSize;
     final private int windowInterval;
     final private ConcurrentLinkedQueue<TimeStamp> queue;
-    final private ForkJoinPool executor;
+    final private ExecutorService executor;
 
     @GuardedBy("this")
     private Future<Void> ret;

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -352,7 +352,6 @@ public class PerfStats {
         if (this.ret != null) {
             queue.add(new TimeStamp(endTime));
             ret.get();
-            executor.shutdownNow();
             queue.clear();
             this.ret = null;
         }

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -67,13 +67,13 @@ public class PerfStats {
         }
     }
 
-    public PerfStats(String action, int reportingInterval, int messageSize, String csvFile) {
+    public PerfStats(String action, int reportingInterval, int messageSize, String csvFile, ExecutorService executor) {
         this.action = action;
         this.messageSize = messageSize;
         this.windowInterval = reportingInterval;
         this.csvFile = csvFile;
+        this.executor = executor;
         this.queue = new ConcurrentLinkedQueue<>();
-        this.executor = new ForkJoinPool(1);
         this.ret = null;
     }
 

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ExecutorService;

--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -84,7 +84,7 @@ public class PerfStats {
         final private static int NS_PER_MICRO = 1000;
         final private static int MICROS_PER_MS = 1000;
         final private static int NS_PER_MS = NS_PER_MICRO * MICROS_PER_MS;
-        final private static int PARK_NS = NS_PER_MICRO;
+        final private static int PARK_NS = NS_PER_MS;
         final private long startTime;
 
         private QueueProcessor(long startTime) {
@@ -95,7 +95,7 @@ public class PerfStats {
             final TimeWindow window = new TimeWindow(action, startTime);
             final LatencyWriter latencyRecorder = csvFile == null ? new LatencyWriter(action, messageSize, startTime) :
                     new CSVLatencyWriter(action, messageSize, startTime, csvFile);
-            final int minWaitTimeMS = windowInterval / 50;
+            final int minWaitTimeMS = windowInterval / 10;
             final long totalIdleCount = (NS_PER_MS / PARK_NS) * minWaitTimeMS;
             boolean doWork = true;
             long time = startTime;

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -284,7 +284,7 @@ public class PravegaPerfTest {
             if (commandline.hasOption("fork")) {
                 fork = Boolean.parseBoolean(commandline.getOptionValue("fork"));
             } else {
-                fork = false;
+                fork = true;
             }
 
             if (commandline.hasOption("throughput")) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -533,7 +533,7 @@ public class PravegaPerfTest {
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, controllerUri);
             props.put(ProducerConfig.ACKS_CONFIG, "all");
             props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
-            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
             // Enabling the producer IDEMPOTENCE is must to compare between Kafka and Pravega
             props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
             return props;
@@ -545,7 +545,7 @@ public class PravegaPerfTest {
             }
             final Properties props = new Properties();
             props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, controllerUri);
-            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
             props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
             props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
             // Enabling the consumer to READ_COMMITTED is must to compare between Kafka and Pravega

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -90,6 +90,7 @@ public class PravegaPerfTest {
         options.addOption("writecsv", true, "CSV file to record write latencies");
         options.addOption("readcsv", true, "CSV file to record read latencies");
         options.addOption("fork", true, "Use Fork join Pool");
+        options.addOption("kafka", true, "Kafka Benchmarking");
 
         options.addOption("help", false, "Help message");
 

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -321,7 +321,7 @@ public class PravegaPerfTest {
             if (fork) {
                 executor = new ForkJoinPool(threadCount);
             } else {
-                executor = Executors.newScheduledThreadPool(threadCount);
+                executor = Executors.newFixedThreadPool(threadCount);
             }
 
             if (recreate) {

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Performance benchmark for Pravega.
@@ -102,7 +103,7 @@ public class PravegaPerfTest {
             System.exit(0);
         }
 
-        final ForkJoinPool executor = new ForkJoinPool();
+        final ExecutorService executor = new ForkJoinPool();
 
         try {
             final List<WriterWorker> producers = perfTest.getProducers();

--- a/src/main/java/io/pravega/perf/ReaderWorker.java
+++ b/src/main/java/io/pravega/perf/ReaderWorker.java
@@ -12,7 +12,6 @@ package io.pravega.perf;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -194,7 +194,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
         for (int i = 0; (time - startTime) < msToRun; i++) {
             time = System.currentTimeMillis();
-            byte[] bytes = timeBuffer.putLong(0, System.currentTimeMillis()).array();
+            byte[] bytes = timeBuffer.putLong(0, time).array();
             System.arraycopy(bytes, 0, payload, 0, bytes.length);
             writeData(payload);
                 /*


### PR DESCRIPTION
**Change log description**  
A new option "-fork" option is added; by default it is set to True; if it is set to false, then new fixed thread pool is used.
Another new option "-kafka" is added; by default it is set to False; it it is set to true, then kafka bench-marking is conducted.

**Purpose of the change**  
Fixes #57 , #60 

**What the code does**  
when user supplies -fork false; conventional thread pool is used; otherwise fork join pool is used.
when user supplied -kafka true; the kafka bench-marking is conducted.

Signed-off-by: Keshava Munegowda <keshava.munegowda@dell.com>