### PR TITLE
Issue 64: Statistics are now logged using the slf4j logger so that timestamps are printed

### DIFF
--- a/src/main/java/io/pravega/perf/PerfStats.java
+++ b/src/main/java/io/pravega/perf/PerfStats.java
@@ -24,6 +24,8 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -33,6 +35,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  * Class for Performance statistics.
  */
 public class PerfStats {
+    private static Logger log = LoggerFactory.getLogger(PerfStats.class);
+
     final private String action;
     final private String csvFile;
     final private int messageSize;
@@ -184,8 +188,8 @@ public class PerfStats {
             final double recsPerSec = count / elapsed;
             final double mbPerSec = (this.bytes / (1024.0 * 1024.0)) / elapsed;
 
-            System.out.printf("%8d records %s, %9.1f records/sec, %6.2f MB/sec, %7.1f ms avg latency, %7.1f ms max latency\n",
-                    count, action, recsPerSec, mbPerSec, totalLatency / (double) count, (double) maxLatency);
+            log.info(String.format("%8d records %s, %9.1f records/sec, %6.2f MiB/sec, %7.1f ms avg latency, %7.1f ms max latency",
+                    count, action, recsPerSec, mbPerSec, totalLatency / (double) count, (double) maxLatency));
         }
 
         /**
@@ -274,11 +278,11 @@ public class PerfStats {
             final double mbPerSec = (this.totalBytes / (1024.0 * 1024.0)) / elapsed;
             int[] percs = getPercentiles();
 
-            System.out.printf(
-                    "%d records %s, %.3f records/sec, %d bytes record size, %.2f MB/sec, %.1f ms avg latency, %.1f ms max latency" +
-                            ", %d ms 50th, %d ms 75th, %d ms 95th, %d ms 99th, %d ms 99.9th, %d ms 99.99th.\n",
+            log.info(String.format(
+                    "%d records %s, %.3f records/sec, %d bytes record size, %.2f MiB/sec, %.1f ms avg latency, %.1f ms max latency" +
+                            ", %d ms 50th, %d ms 75th, %d ms 95th, %d ms 99th, %d ms 99.9th, %d ms 99.99th.",
                     count, action, recsPerSec, messageSize, mbPerSec, totalLatency / ((double) count), (double) maxLatency,
-                    percs[0], percs[1], percs[2], percs[3], percs[4], percs[5]);
+                    percs[0], percs[1], percs[2], percs[3], percs[4], percs[5]));
         }
     }
 

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -13,13 +13,13 @@ org.slf4j.simpleLogger.defaultLogLevel=info
 
 # Set to true if you want the current date and time to be included in output messages.
 # Default is false, and will output the number of milliseconds elapsed since startup.
-#org.slf4j.simpleLogger.showDateTime=false
+org.slf4j.simpleLogger.showDateTime=true
 
 # The date and time format to be used in the output messages.
 # The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
 # If the format is not specified or is invalid, the default format is used.
 # The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
-#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
 
 # Set to true if you want to output the current thread name.
 # Defaults to true.


### PR DESCRIPTION
Statistics are now logged using the slf4j logger so that timestamps are printed