### PR TITLE
Issue 52: Removed createScope to allow this to run in Nautilus

### DIFF
--- a/src/main/java/io/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamHandler.java
@@ -66,7 +66,6 @@ public class PravegaStreamHandler {
         this.timeout = timeout;
         this.bgexecutor = bgexecutor;
         streamManager = StreamManager.create(new URI(uri));
-        streamManager.createScope(scope);
         streamconfig = StreamConfiguration.builder().scope(scope).streamName(stream)
                 .scalingPolicy(ScalingPolicy.fixed(segCount))
                 .build();


### PR DESCRIPTION
Best-practices for Pravega is to never create a scope. In Nautilus, scopes cannot be created by a normal project user. Outside of Nautilus, scopes can be created using a simple curl command such as
```
curl -X POST -H "Content-Type: application/json" -d '{"scopeName":"examples"}' http://localhost:10080/v1/scopes
```
Signed-off-by: Claudio Fahey <claudio.fahey@dell.com>