### PR TITLE
Issue 69: Added ability to write and read watermarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,35 +47,52 @@ Running Pravega benchmark tool locally:
 ```
 <dir>/pravega-benchmark$ ./run/pravega-benchmark/bin/pravega-benchmark  -help
 usage: pravega-benchmark
- -consumers <arg>                 Number of consumers
- -controller <arg>                Controller URI
- -enableConnectionPooling <arg>   Set to false to disable connection
-                                  pooling
- -events <arg>                    Number of events/records if 'time' not
-                                  specified;
-                                  otherwise, Maximum events per second by
-                                  producer(s) and/or Number of events per
-                                  consumer
- -flush <arg>                     Each producer calls flush after writing
-                                  <arg> number of of events/records; Not
-                                  applicable, if both producers and
-                                  consumers are specified
- -help                            Help message
- -producers <arg>                 Number of producers
- -readcsv <arg>                   CSV file to record read latencies
- -recreate <arg>                  If the stream is already existing,
-                                  delete and recreate the same
- -scope <arg>                     Scope name
- -segments <arg>                  Number of segments
- -size <arg>                      Size of each message (event or record)
- -stream <arg>                    Stream name
- -throughput <arg>                if > 0 , throughput in MB/s
-                                  if 0 , writes 'events'
-                                  if -1, get the maximum throughput
- -time <arg>                      Number of seconds the code runs
- -transactionspercommit <arg>     Number of events before a transaction is
-                                  committed
- -writecsv <arg>                  CSV file to record write latencies
+ -consumers <arg>                    Number of consumers
+ -controller <arg>                   Controller URI
+ -enableConnectionPooling <arg>      Set to false to disable connection
+                                     pooling
+ -events <arg>                       Number of events/records if 'time'
+                                     not specified;
+                                     otherwise, Maximum events per second
+                                     by producer(s) and/or Number of
+                                     events per consumer
+ -flush <arg>                        Each producer calls flush after
+                                     writing <arg> number of of
+                                     events/records; Not applicable, if
+                                     both producers and consumers are
+                                     specified
+ -help                               Help message
+ -producers <arg>                    Number of producers
+ -readcsv <arg>                      CSV file to record read latencies
+ -readWatermarkPeriodMillis <arg>    If -1 (default), watermarks will not
+                                     be read.
+                                     If >0, watermarks will be read with a
+                                     period of this many milliseconds.
+ -recreate <arg>                     If the stream is already existing,
+                                     delete and recreate the same
+ -scope <arg>                        Scope name
+ -segments <arg>                     Number of segments
+ -size <arg>                         Size of each message (event or
+                                     record)
+ -stream <arg>                       Stream name
+ -throughput <arg>                   if > 0 , throughput in MB/s
+                                     if 0 , writes 'events'
+                                     if -1, get the maximum throughput
+ -time <arg>                         Number of seconds the code runs
+ -transactionspercommit <arg>        Number of events before a transaction
+                                     is committed
+ -writecsv <arg>                     CSV file to record write latencies
+ -writeWatermarkPeriodMillis <arg>   If -1 (default), watermarks will not
+                                     be written.
+                                     If 0 and not using transactions,
+                                     watermarks will be written after
+                                     every event.
+                                     If >0 and not using transactions,
+                                     watermarks will be written with a
+                                     period of this many milliseconds.
+                                     If >= 0 and using transactions,
+                                     watermarks will be written on each
+                                     commit.
 
 ## Running Performance benchmarking
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ buildscript {
         mavenLocal()
         jcenter()
         mavenCentral()
+        maven {
+            url "https://oss.jfrog.org/jfrog-dependencies"
+        }
     }
 
     dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@
 
 commonsCLIVersion=1.3.1
 commonsCSVVersion=1.5
-pravegaVersion=0.5.0
+pravegaVersion=0.6.0-2364.fb3423a-SNAPSHOT
 slf4jSimpleVersion=1.7.14

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@
 
 commonsCLIVersion=1.3.1
 commonsCSVVersion=1.5
-pravegaVersion=0.6.0-2364.fb3423a-SNAPSHOT
+pravegaVersion=0.6.0-50.fb3423a-SNAPSHOT
 slf4jSimpleVersion=1.7.14

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -80,12 +80,12 @@ public class PravegaPerfTest {
         options.addOption("readcsv", true, "CSV file to record read latencies");
         options.addOption("enableConnectionPooling", true, "Set to false to disable connection pooling");
         options.addOption("writeWatermarkPeriodMillis", true,
-                "If -1, watermarks will not be written.\n" +
+                "If -1 (default), watermarks will not be written.\n" +
                 "If 0 and not using transactions, watermarks will be written after every event.\n" +
                 "If >0 and not using transactions, watermarks will be written with a period of this many milliseconds.\n" +
                 "If >= 0 and using transactions, watermarks will be written on each commit.");
         options.addOption("readWatermarkPeriodMillis", true,
-                "If -1, watermarks will not be read.\n" +
+                "If -1 (default), watermarks will not be read.\n" +
                 "If >0, watermarks will be read with a period of this many milliseconds.");
 
         options.addOption("help", false, "Help message");

--- a/src/main/java/io/pravega/perf/PravegaReaderWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaReaderWorker.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
  * Class for Pravega reader/consumer.
  */
 public class PravegaReaderWorker extends ReaderWorker {
-    private static Logger log = LoggerFactory.getLogger(PravegaWriterWorker.class);
+    private static Logger log = LoggerFactory.getLogger(PravegaReaderWorker.class);
 
     private final EventStreamReader<byte[]> reader;
     private final Stream stream;

--- a/src/main/java/io/pravega/perf/PravegaReaderWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaReaderWorker.java
@@ -66,7 +66,7 @@ public class PravegaReaderWorker extends ReaderWorker {
 
     private void readWatermark() {
         TimeWindow currentTimeWindow = reader.getCurrentTimeWindow(stream);
-        log.info("readWatermark: currentTimeWindow={}", currentTimeWindow);
+        log.debug("readWatermark: currentTimeWindow={}", currentTimeWindow);
     }
 
     @Override

--- a/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
@@ -90,7 +90,7 @@ public class PravegaTransactionWriterWorker extends WriterWorker {
                 if (eventCount >= transactionsPerCommit) {
                     eventCount = 0;
                     if (enableWatermark) {
-                        log.info("recordWrite: commit({})", time);
+                        log.debug("recordWrite: commit({})", time);
                         transaction.commit(time);
                     } else {
                         transaction.commit();
@@ -123,7 +123,7 @@ public class PravegaTransactionWriterWorker extends WriterWorker {
                 if (transaction != null) {
                     if (enableWatermark) {
                         long time = System.currentTimeMillis();
-                        log.info("flush: commit({})", time);
+                        log.debug("flush: commit({})", time);
                         transaction.commit(time);
                     } else {
                         transaction.commit();

--- a/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaTransactionWriterWorker.java
@@ -11,22 +11,30 @@
 package io.pravega.perf;
 
 import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Transaction;
+import io.pravega.client.stream.TransactionalEventStreamWriter;
 import io.pravega.client.stream.TxnFailedException;
+import io.pravega.client.stream.impl.ByteArraySerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
+import java.util.UUID;
 
-public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
+public class PravegaTransactionWriterWorker extends WriterWorker {
     private static Logger log = LoggerFactory.getLogger(PravegaTransactionWriterWorker.class);
 
+    private static TriConsumer noOpTriConsumer = (a, b, c) -> {};
+
+    private final TransactionalEventStreamWriter<byte[]> producer;
     private final int transactionsPerCommit;
     private final boolean enableWatermark;
 
     @GuardedBy("this")
     private int eventCount;
 
+    // If null, a transaction has not been started.
     @GuardedBy("this")
     private Transaction<byte[]> transaction;
 
@@ -40,22 +48,42 @@ public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
                                    PerfStats stats, String streamName, int eventsPerSec, boolean writeAndRead,
                                    EventStreamClientFactory factory, int transactionsPerCommit, boolean enableConnectionPooling,
                                    boolean enableWatermark) {
-        super(sensorId, events, Integer.MAX_VALUE, secondsToRun, isRandomKey,
-                messageSize, start, stats, streamName, eventsPerSec, writeAndRead, factory, enableConnectionPooling,
-                -1);
+        super(sensorId, events, Integer.MAX_VALUE,
+                secondsToRun, isRandomKey, messageSize, start,
+                stats, streamName, eventsPerSec, writeAndRead);
 
+        final String writerId = UUID.randomUUID().toString();
+        this.producer = factory.createTransactionalEventWriter(
+                writerId,
+                streamName,
+                new ByteArraySerializer(),
+                EventWriterConfig.builder()
+                        .enableConnectionPooling(enableConnectionPooling)
+                        .build());
         this.transactionsPerCommit = transactionsPerCommit;
         this.enableWatermark = enableWatermark;
+
         eventCount = 0;
-        transaction = producer.beginTxn();
     }
 
+    /**
+     * Writes an event in a transaction. It will begin a new transaction if needed.
+     * It periodically commits the current transaction.
+     * Called directly by write-only tests.
+     *
+     * @param data   data to write
+     * @param record to call to record statistics
+     * @return the current time
+     */
     @Override
     public long recordWrite(byte[] data, TriConsumer record) {
         long time = 0;
         try {
             synchronized (this) {
                 time = System.currentTimeMillis();
+                if (transaction == null) {
+                    transaction = producer.beginTxn();
+                }
                 transaction.writeEvent(data);
                 record.accept(time, System.currentTimeMillis(), messageSize);
                 eventCount++;
@@ -67,12 +95,53 @@ public class PravegaTransactionWriterWorker extends PravegaWriterWorker {
                     } else {
                         transaction.commit();
                     }
-                    transaction = producer.beginTxn();
+                    transaction = null;
                 }
             }
         } catch (TxnFailedException e) {
             throw new RuntimeException("Transaction Write data failed ", e);
         }
         return time;
+    }
+
+    /**
+     * Used only by read-write tests.
+     * @param data data to write
+     */
+    @Override
+    public void writeData(byte[] data) {
+        recordWrite(data, noOpTriConsumer);
+    }
+
+    /**
+     * Commits the current transaction if it exists.
+     */
+    @Override
+    public void flush() {
+        try {
+            synchronized (this) {
+                if (transaction != null) {
+                    if (enableWatermark) {
+                        long time = System.currentTimeMillis();
+                        log.info("flush: commit({})", time);
+                        transaction.commit(time);
+                    } else {
+                        transaction.commit();
+                    }
+                    transaction = null;
+                }
+            }
+        } catch (TxnFailedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (transaction != null) {
+            transaction.abort();
+            transaction = null;
+        }
+        producer.close();
     }
 }

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -28,6 +28,8 @@ public class PravegaWriterWorker extends WriterWorker {
     final EventStreamWriter<byte[]> producer;
 
     private final long writeWatermarkPeriodMillis;
+
+    // No guard is required for nextNoteTime because it is only used by one thread per instance.
     private long nextNoteTime = System.currentTimeMillis();
 
     /**

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -33,6 +33,7 @@ public class PravegaWriterWorker extends WriterWorker {
     private long nextNoteTime = System.currentTimeMillis();
 
     /**
+     * Construct a PravegaWriterWorker.
      *
      * @param writeWatermarkPeriodMillis If 0, noteTime will be called after every event.
      *                             If -1, noteTime will never be called.

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -12,8 +12,8 @@ package io.pravega.perf;
 
 import java.util.concurrent.CompletableFuture;
 
+import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.ClientFactory;
 import io.pravega.client.stream.impl.ByteArraySerializer;
 import io.pravega.client.stream.EventWriterConfig;
 import org.slf4j.Logger;
@@ -27,11 +27,20 @@ public class PravegaWriterWorker extends WriterWorker {
 
     final EventStreamWriter<byte[]> producer;
 
+    private final long writeWatermarkPeriodMillis;
+    private long nextNoteTime = System.currentTimeMillis();
+
+    /**
+     *
+     * @param writeWatermarkPeriodMillis If 0, noteTime will be called after every event.
+     *                             If -1, noteTime will never be called.
+     *                             If >0, noteTime will be called with a period of this many milliseconds.
+     */
     PravegaWriterWorker(int sensorId, int events, int EventsPerFlush, int secondsToRun,
                         boolean isRandomKey, int messageSize, long start,
                         PerfStats stats, String streamName, int eventsPerSec,
-                        boolean writeAndRead, ClientFactory factory,
-                        boolean enableConnectionPooling) {
+                        boolean writeAndRead, EventStreamClientFactory factory,
+                        boolean enableConnectionPooling, long writeWatermarkPeriodMillis) {
 
         super(sensorId, events, EventsPerFlush,
                 secondsToRun, isRandomKey, messageSize, start,
@@ -42,6 +51,7 @@ public class PravegaWriterWorker extends WriterWorker {
                 EventWriterConfig.builder()
                         .enableConnectionPooling(enableConnectionPooling)
                         .build());
+        this.writeWatermarkPeriodMillis = writeWatermarkPeriodMillis;
     }
 
     @Override
@@ -52,12 +62,25 @@ public class PravegaWriterWorker extends WriterWorker {
         ret.thenAccept(d -> {
             record.accept(time, System.currentTimeMillis(), data.length);
         });
+        noteTimePeriodically();
         return time;
     }
 
     @Override
     public void writeData(byte[] data) {
         producer.writeEvent(data);
+        noteTimePeriodically();
+    }
+
+    private void noteTimePeriodically() {
+        if (writeWatermarkPeriodMillis >= 0) {
+            final long time = System.currentTimeMillis();
+            if (time > nextNoteTime) {
+                producer.noteTime(time);
+                log.info("noteTimePeriodically: noteTime({})", time);
+                nextNoteTime += writeWatermarkPeriodMillis;
+            }
+        }
     }
 
     @Override

--- a/src/main/java/io/pravega/perf/PravegaWriterWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaWriterWorker.java
@@ -77,7 +77,7 @@ public class PravegaWriterWorker extends WriterWorker {
             final long time = System.currentTimeMillis();
             if (time > nextNoteTime) {
                 producer.noteTime(time);
-                log.info("noteTimePeriodically: noteTime({})", time);
+                log.debug("noteTimePeriodically: noteTime({})", time);
                 nextNoteTime += writeWatermarkPeriodMillis;
             }
         }

--- a/src/main/java/io/pravega/perf/WriterWorker.java
+++ b/src/main/java/io/pravega/perf/WriterWorker.java
@@ -10,6 +10,9 @@
 
 package io.pravega.perf;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -21,6 +24,8 @@ import java.util.concurrent.ExecutionException;
  * Abstract class for Writers.
  */
 public abstract class WriterWorker extends Worker implements Callable<Void> {
+    private static Logger log = LoggerFactory.getLogger(WriterWorker.class);
+
     final private static int MS_PER_SEC = 1000;
     final private Performance perf;
     final private byte[] payload;
@@ -118,6 +123,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     private void EventsWriter() throws InterruptedException, IOException {
+        log.info("EventsWriter: Running");
         for (int i = 0; i < events; i++) {
             recordWrite(payload, stats::recordTime);
         }
@@ -126,6 +132,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     private void EventsWriterSleep() throws InterruptedException, IOException {
+        log.info("EventsWriterSleep: Running");
         final EventsController eCnt = new EventsController(System.currentTimeMillis(), eventsPerSec);
         int cnt = 0;
         while (cnt < events) {
@@ -139,6 +146,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     private void EventsWriterTime() throws InterruptedException, IOException {
+        log.info("EventsWriterTime: Running");
         final long msToRun = secondsToRun * MS_PER_SEC;
         long time = System.currentTimeMillis();
         while ((time - startTime) < msToRun) {
@@ -149,6 +157,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     private void EventsWriterTimeSleep() throws InterruptedException, IOException {
+        log.info("EventsWriterTimeSleep: Running");
         final long msToRun = secondsToRun * MS_PER_SEC;
         long time = System.currentTimeMillis();
         final EventsController eCnt = new EventsController(time, eventsPerSec);
@@ -166,6 +175,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     private void EventsWriterRW() throws InterruptedException, IOException {
+        log.info("EventsWriterRW: Running");
         final ByteBuffer timeBuffer = ByteBuffer.allocate(TIME_HEADER_SIZE);
         final long time = System.currentTimeMillis();
         final EventsController eCnt = new EventsController(time, eventsPerSec);
@@ -187,6 +197,7 @@ public abstract class WriterWorker extends Worker implements Callable<Void> {
 
 
     private void EventsWriterTimeRW() throws InterruptedException, IOException {
+        log.info("EventsWriterTimeRW: Running");
         final long msToRun = secondsToRun * MS_PER_SEC;
         final ByteBuffer timeBuffer = ByteBuffer.allocate(TIME_HEADER_SIZE);
         long time = System.currentTimeMillis();


### PR DESCRIPTION
This PR adds optional parameters to control writing and reading of watermarks. 
```
 -readWatermarkPeriodMillis <arg>    If -1 (default), watermarks will not
                                     be read.
                                     If >0, watermarks will be read with a
                                     period of this many milliseconds.
-writeWatermarkPeriodMillis <arg>   If -1 (default), watermarks will not
                                     be written.
                                     If 0 and not using transactions,
                                     watermarks will be written after
                                     every event.
                                     If >0 and not using transactions,
                                     watermarks will be written with a
                                     period of this many milliseconds.
                                     If >= 0 and using transactions,
                                     watermarks will be written on each
                                     commit.
```