### PR TITLE
Issue 16: Remove deprecated Pravega API usage

### DIFF
--- a/src/main/java/io/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamHandler.java
@@ -67,7 +67,7 @@ public class PravegaStreamHandler {
         this.bgexecutor = bgexecutor;
         streamManager = StreamManager.create(new URI(uri));
         streamManager.createScope(scope);
-        streamconfig = StreamConfiguration.builder().scope(scope).streamName(stream)
+        streamconfig = StreamConfiguration.builder()
                 .scalingPolicy(ScalingPolicy.fixed(segCount))
                 .build();
     }


### PR DESCRIPTION
**Change log description**
Remove remaining usage of deprecated Pravega APIs.

**Purpose of the change**
Fixes #16.

**What the code does**
While most of the code for Pravega Benchmark has been updated in terms of Pravega APIs usage, there was a point in the code making use of deprecated `StreamConfiguration` methods. This PR fixes this problem by removing the deprecated calls.

**How to verify it**
Build passes without deprecation warnings.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>