### PR TITLE
Issue 85: Add Stream auto-scaling option in Pravega Benchmark

### DIFF
--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -50,7 +50,6 @@ public class PravegaPerfTest {
         final HelpFormatter formatter = new HelpFormatter();
         final CommandLineParser parser;
         CommandLine commandline = null;
-        Option opt = null;
         final long startTime = System.currentTimeMillis();
 
         options.addOption("controller", true, "Controller URI");
@@ -75,7 +74,7 @@ public class PravegaPerfTest {
                 "This option tells the throughput in events/second that a Stream segment should receive to be candidate for split (scaleFactor new segments will be created).");
         options.addOption("scaleFactor", true, "If the scale policy is configured, this parameter defines the number of new segments" +
                 "to be created once Pravega determines to split a segment.");
-                options.addOption("size", true, "Size of each message (event or record)");
+        options.addOption("size", true, "Size of each message (event or record)");
         options.addOption("recreate", true,
                 "If the stream is already existing, delete and recreate the same");
         options.addOption("throughput", true,

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -68,10 +68,10 @@ public class PravegaPerfTest {
         options.addOption("time", true, "Number of seconds the code runs");
         options.addOption("transactionspercommit", true,
                 "Number of events before a transaction is committed");
-        options.addOption("segments", true, "Number of segments");
-        options.addOption("segmentScaleKBps", true, "Setting this option enables Stream auto-scaling." +
+        options.addOption("segments", true, "Number of segments. If Stream auto-scaling is enabled, this is the initial number of segments.");
+        options.addOption("segmentScaleKBps", true, "Setting this option enables Stream auto-scaling. " +
                 "This option tells the throughput in KBps that a Stream segment should receive to be candidate for split (scaleFactor new segments will be created).");
-        options.addOption("segmentScaleEventsPerSecond", true, "Setting this option enables Stream auto-scaling." +
+        options.addOption("segmentScaleEventsPerSecond", true, "Setting this option enables Stream auto-scaling. " +
                 "This option tells the throughput in events/second that a Stream segment should receive to be candidate for split (scaleFactor new segments will be created).");
         options.addOption("scaleFactor", true, "If the scale policy is configured, this parameter defines the number of new segments" +
                 "to be created once Pravega determines to split a segment.");


### PR DESCRIPTION
**Change log description**
Adds the ability to create Stream with auto-scaling policies in Pravega Benchmark.

**Purpose of the change**
Fixes #85.

**What the code does**
This PR adds 3 new options for the parameterization of the tool (`segmentScaleKBps`, `segmentScaleEventsPerSecond `, `scaleFactor` ):
```
 -scaleFactor <arg>                   If the scale policy is configured,
                                      this parameter defines the number of
                                      new segmentsto be created once
                                      Pravega determines to split a
                                      segment.
 -segmentScaleEventsPerSecond <arg>   Setting this option enables Stream
                                      auto-scaling.This option tells the
                                      throughput in events/second that a
                                      Stream segment should receive to be
                                      candidate for split (scaleFactor new
                                      segments will be created).
 -segmentScaleKBps <arg>              Setting this option enables Stream
                                      auto-scaling.This option tells the
                                      throughput in KBps that a Stream
                                      segment should receive to be
                                      candidate for split (scaleFactor new
                                      segments will be created).
```
While the default behavior remains the same (Streams have fixed scaling policies), these options now allow us to exercise autoscaling with Pravega benchmark.

**How to verify it**
Executed several benchmarks with scaling policies enabled, and confirmed that autoscaling is triggered on the Streams:
```
./bin/pravega-benchmark -controller tcp://xxx:9090 -producers 1 -size 1000 -segments 1 -segmentScaleEventsPerSecond 100 -events 1000 -time 10000 -stream newStreamScaleEps -scaleFactor 4
```
Note that the policy is correctly submitted in the create stream requests:
```
2020-01-03 15:21:34:815 +0000 [main] INFO io.pravega.client.admin.impl.StreamManagerImpl - Creating scope/stream: Scope/newStreamScaleEps with configuration: StreamConfiguration(scalingPolicy=ScalingPolicy(scaleType=BY_RATE_IN_EVENTS_PER_SEC, targetRate=100, scaleFactor=4, minNumSegments=1), retentionPolicy=null, timestampAggregationTimeout=0)
```
Looking at the `AutoScaleProcessor` logs, we can observe that scale up takes place:
```
2020-01-03 15:20:14,611 11923 [auto-scaler-2] INFO  i.p.s.s.h.stat.AutoScaleProcessor - AutoScale Processor Initialized. RequestStream=_requeststream
2020-01-03 15:23:35,244 212556 [auto-scaler-1] INFO  i.p.s.s.h.stat.AutoScaleProcessor - received traffic for Scope/newStreamScaleEps/0.#epoch.0 with twoMinute rate = 971.7989782980599 and targetRate = 100
2020-01-03 15:25:35,254 332566 [auto-scaler-6] INFO  i.p.s.s.h.stat.AutoScaleProcessor - received traffic for Scope/newStreamScaleEps/0.#epoch.0 with twoMinute rate = 989.5801564349287 and targetRate = 100
2020-01-03 15:27:35,261 452573 [auto-scaler-9] INFO  i.p.s.s.h.stat.AutoScaleProcessor - received traffic for Scope/newStreamScaleEps/0.#epoch.0 with twoMinute rate = 996.1767984195764 and targetRate = 100
2020-01-03 15:29:35,265 572577 [auto-scaler-1] INFO  i.p.s.s.h.stat.AutoScaleProcessor - received traffic for Scope/newStreamScaleEps/0.#epoch.0 with twoMinute rate = 998.5686043110853 and targetRate = 100
2020-01-03 15:31:35,272 692584 [auto-scaler-5] INFO  i.p.s.s.h.stat.AutoScaleProcessor - received traffic for Scope/newStreamScaleEps/0.#epoch.0 with twoMinute rate = 999.4689404006488 and targetRate = 100
2020-01-03 15:31:35,273 692585 [auto-scaler-5] INFO  i.p.s.s.h.stat.AutoScaleProcessor - [requestId=-5476528379974446203] sending request for scale up for Scope/newStreamScaleEps/0.#epoch.0
```
And the metrics confirm that the number of segments has increased by `scaleFactor`:
<img width="951" alt="autoscaling" src="https://user-images.githubusercontent.com/717112/71732280-249c4c00-2e47-11ea-9ee9-e1d94ea2397c.png">
