### PR TITLE
Issue 89 Add Batch Reader Support

### DIFF
--- a/src/main/java/io/pravega/perf/PravegaBatchReaderWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaBatchReaderWorker.java
@@ -1,0 +1,66 @@
+package io.pravega.perf;
+
+import io.pravega.client.BatchClientFactory;
+import io.pravega.client.batch.SegmentIterator;
+import io.pravega.client.batch.SegmentRange;
+import io.pravega.client.stream.impl.ByteArraySerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class PravegaBatchReaderWorker extends ReaderWorker {
+    private static Logger log = LoggerFactory.getLogger(PravegaBatchReaderWorker.class);
+
+    private final BatchClientFactory batchClientFactory;
+    private final Iterator<SegmentRange> assignedSegments;
+
+    private SegmentIterator<byte[]> currentSegmentIterator;
+    private SegmentRange currentRange;
+    private boolean finished;
+
+    PravegaBatchReaderWorker(int readerId, int events, int secondsToRun, long start, PerfStats stats, String readerGrp, int timeout, boolean writeAndRead, BatchClientFactory batchClientFactory, List<SegmentRange> assignedSegments) {
+        super(readerId, events, secondsToRun, start, stats, readerGrp, timeout, writeAndRead);
+        this.batchClientFactory = batchClientFactory;
+
+        this.assignedSegments = assignedSegments.iterator();
+    }
+
+    @Override
+    public byte[] readData() {
+        if (finished) {
+            return null;
+        }
+
+        if (currentSegmentIterator == null || !currentSegmentIterator.hasNext()) {
+            if (currentRange != null) {
+                currentSegmentIterator.close();
+
+                log.info("id:{} Completed Segment {}, {}({}:{})",workerID, currentRange.getStreamName(), currentRange.getSegmentId(), currentRange.getStartOffset(), currentRange.getEndOffset());
+            }
+
+            if (assignedSegments.hasNext()) {
+
+                currentRange = assignedSegments.next();
+                currentSegmentIterator = batchClientFactory.readSegment(currentRange, new ByteArraySerializer());
+
+                log.info("id:{} Starting Segment {}, {}({}:{})",workerID, currentRange.getStreamName(), currentRange.getSegmentId(), currentRange.getStartOffset(), currentRange.getEndOffset());
+            } else {
+                log.info("id:{} Completed all assigned assignedSegments", workerID);
+                currentSegmentIterator = null;
+                finished = true;
+                return null;
+            }
+        }
+
+        return currentSegmentIterator.next();
+    }
+
+    @Override
+    public void close() {
+        if (currentSegmentIterator != null) {
+            currentSegmentIterator.close();
+        }
+    }
+}

--- a/src/main/java/io/pravega/perf/PravegaStreamingReaderWorker.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamingReaderWorker.java
@@ -27,8 +27,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * Class for Pravega reader/consumer.
  */
-public class PravegaReaderWorker extends ReaderWorker {
-    private static Logger log = LoggerFactory.getLogger(PravegaReaderWorker.class);
+public class PravegaStreamingReaderWorker extends ReaderWorker {
+    private static Logger log = LoggerFactory.getLogger(PravegaStreamingReaderWorker.class);
 
     private final EventStreamReader<byte[]> reader;
     private final Stream stream;
@@ -38,10 +38,10 @@ public class PravegaReaderWorker extends ReaderWorker {
      *
      * @param readWatermarkPeriodMillis If >0, watermarks will be read with a period of this many milliseconds.
      */
-    PravegaReaderWorker(int readerId, int events, int secondsToRun,
-                        long start, PerfStats stats, String readergrp,
-                        int timeout, boolean writeAndRead, EventStreamClientFactory factory,
-                        Stream stream, long readWatermarkPeriodMillis) {
+    PravegaStreamingReaderWorker(int readerId, int events, int secondsToRun,
+                                 long start, PerfStats stats, String readergrp,
+                                 int timeout, boolean writeAndRead, EventStreamClientFactory factory,
+                                 Stream stream, long readWatermarkPeriodMillis) {
         super(readerId, events, secondsToRun, start, stats, readergrp, timeout, writeAndRead);
 
         final String readerSt = Integer.toString(readerId);


### PR DESCRIPTION
**Change log description**
Adds support for using the BatchReader instead of the StreamingReader within consumers

**Purpose of the change**
Fixes #89

**What the code does**
When reading historic data from a stream data can be read using either the Streaming Reader or the Batch (bounded) Reader.  This adds a new `-batchreaders` option that signifies that the stream should be consumed using the BatchClient.  In this mode all the segments from with a Stream bound are supplied by the Pravega Client and the consumers are free to consume them in any order.

The existing consumer has been renamed `PravegaStreamingReaderWorker` and a new `PravegaBatchReaderWorker` has been introduced.  Each reader is assigned a certain number of the Batch segments with an attempt to give each consumer an equal number of the segments.  If the segment count is lower than the number of specified consumers then the consumer count is reduced so that there is one consumer per Batch segment.

```
 -batchreaders                       signifies the consumers should all be
                                     Batch Readers rather than Streaming
                                     readers
```
**How to verify**
When running with the `-batchreaders` option the test will log the consumer to segment assignments
```
>pravega-benchmark -controller tcp://localhost:9090 -consumers 10 -scope dave -stream test6 -segments 5 -time 20 -batchreaders
...
...
...
2020-01-12 13:16:49:359 +0000 [main] INFO io.pravega.perf.PravegaPerfTest - Limiting To 5 consumers due to small number of segment ranges
2020-01-12 13:16:49:359 +0000 [main] INFO io.pravega.perf.PravegaPerfTest - Segment Assignment 0 -> test6 0(0:2215032)
2020-01-12 13:16:49:359 +0000 [main] INFO io.pravega.perf.PravegaPerfTest - Segment Assignment 1 -> test6 1(0:2175864)
2020-01-12 13:16:49:359 +0000 [main] INFO io.pravega.perf.PravegaPerfTest - Segment Assignment 2 -> test6 2(0:2194224)
2020-01-12 13:16:49:359 +0000 [main] INFO io.pravega.perf.PravegaPerfTest - Segment Assignment 3 -> test6 3(0:2177904)
2020-01-12 13:16:49:359 +0000 [main] INFO io.pravega.perf.PravegaPerfTest - Segment Assignment 4 -> test6 4(0:2189328)
```
As the consumers progress through thier assigned segments ranges they will also log progress:
```
2020-01-12 13:16:49:379 +0000 [ForkJoinPool-2-worker-4] INFO io.pravega.perf.PravegaBatchReaderWorker - id:3 Starting Segment test6, 3(0:2177904)
2020-01-12 13:16:49:379 +0000 [ForkJoinPool-2-worker-3] INFO io.pravega.perf.PravegaBatchReaderWorker - id:2 Starting Segment test6, 2(0:2194224)
2020-01-12 13:16:49:379 +0000 [ForkJoinPool-2-worker-1] INFO io.pravega.perf.PravegaBatchReaderWorker - id:0 Starting Segment test6, 0(0:2215032)
2020-01-12 13:16:49:379 +0000 [ForkJoinPool-2-worker-5] INFO io.pravega.perf.PravegaBatchReaderWorker - id:4 Starting Segment test6, 4(0:2189328)
2020-01-12 13:16:49:379 +0000 [ForkJoinPool-2-worker-2] INFO io.pravega.perf.PravegaBatchReaderWorker - id:1 Starting Segment test6, 1(0:2175864)
...
...
2020-01-12 13:16:49:595 +0000 [ForkJoinPool-2-worker-2] INFO io.pravega.perf.PravegaBatchReaderWorker - id:1 Completed Segment test6, 1(0:2175864)
2020-01-12 13:16:49:595 +0000 [ForkJoinPool-2-worker-2] INFO io.pravega.perf.PravegaBatchReaderWorker - id:1 Completed all assigned assignedSegments
2020-01-12 13:16:49:601 +0000 [ForkJoinPool-2-worker-4] INFO io.pravega.perf.PravegaBatchReaderWorker - id:3 Completed Segment test6, 3(0:2177904)
2020-01-12 13:16:49:601 +0000 [ForkJoinPool-2-worker-3] INFO io.pravega.perf.PravegaBatchReaderWorker - id:2 Completed Segment test6, 2(0:2194224)
2020-01-12 13:16:49:601 +0000 [ForkJoinPool-2-worker-4] INFO io.pravega.perf.PravegaBatchReaderWorker - id:3 Completed all assigned assignedSegments
2020-01-12 13:16:49:601 +0000 [ForkJoinPool-2-worker-3] INFO io.pravega.perf.PravegaBatchReaderWorker - id:2 Completed all assigned assignedSegments
...
...
```

Signed-off-by: David Maddison <david.maddison@dell.com>