### PR TITLE
Issue 73: Include Pravega Keycloak Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,8 @@ buildscript {
                 "commons-cli:commons-cli:${commonsCLIVersion}",
                 "org.apache.commons:commons-csv:${commonsCSVVersion}"
 
-        runtime "org.slf4j:slf4j-simple:${slf4jSimpleVersion}"
+        runtime "org.slf4j:slf4j-simple:${slf4jSimpleVersion}",
+                "io.pravega:pravega-keycloak-client:${pravegaKeycloakVersion}"
     }
 mainClassName = "io.pravega.perf.PravegaPerfTest"
 startScripts {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,5 @@
 commonsCLIVersion=1.3.1
 commonsCSVVersion=1.5
 pravegaVersion=0.7.0-50.ef40b45-SNAPSHOT
+pravegaKeycloakVersion=0.6.0-6.1a4bae7-SNAPSHOT
 slf4jSimpleVersion=1.7.14


### PR DESCRIPTION
**Change log description**
Include the Pravega Client Keycloak authentication plugin

**Purpose of the change**
Fixes #73

**What the code does**
Includes the Pravega Keycloak Authentication Plugin as a runtime dependency.  This plugin is required for communication with Pravega where Pravega has been configured with Keycloak security.

The plugin will ONLY be initialized and used by the Pravega client when it detects the correct environment variables.  If these environment variables are NOT set then the Jar is completely benign. This means the same classpath works in both secure and unsecure Pravega environments.

Signed-off-by: David Maddison <david.maddison@dell.com>