### PR TITLE
Issue 94: Log test parameters at start of run

### DIFF
--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -20,9 +20,10 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -43,6 +44,7 @@ import java.util.stream.Stream;
  * Data format is in comma separated format as following: {TimeStamp, Sensor Id, Location, TempValue }.
  */
 public class PravegaPerfTest {
+    private static Logger log = LoggerFactory.getLogger(PravegaPerfTest.class);
     final static String BENCHMARKNAME = "pravega-benchmark";
 
     public static void main(String[] args) {
@@ -389,6 +391,9 @@ public class PravegaPerfTest {
 
         PravegaTest(long startTime, CommandLine commandline) throws Exception {
             super(startTime, commandline);
+
+            log.info("Test Parameters: {}", toString());
+
             final ScheduledExecutorService bgExecutor = Executors.newScheduledThreadPool(10);
             final ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder()
                     .clientConfig(ClientConfig.builder().controllerURI(new URI(controllerUri)).build())
@@ -471,5 +476,33 @@ public class PravegaPerfTest {
             }
         }
 
+        @Override
+        public String toString() {
+            return "streamName='" + streamName + '\'' +
+                ", rdGrpName='" + rdGrpName + '\'' +
+                ", scopeName='" + scopeName + '\'' +
+                ", recreate=" + recreate +
+                ", writeAndRead=" + writeAndRead +
+                ", producerCount=" + producerCount +
+                ", consumerCount=" + consumerCount +
+                ", segmentCount=" + segmentCount +
+                ", segmentScaleKBps=" + segmentScaleKBps +
+                ", segmentScaleEventsPerSecond=" + segmentScaleEventsPerSecond +
+                ", scaleFactor=" + scaleFactor +
+                ", events=" + events +
+                ", eventsPerSec=" + eventsPerSec +
+                ", eventsPerProducer=" + eventsPerProducer +
+                ", eventsPerConsumer=" + eventsPerConsumer +
+                ", EventsPerFlush=" + EventsPerFlush +
+                ", transactionPerCommit=" + transactionPerCommit +
+                ", runtimeSec=" + runtimeSec +
+                ", throughput=" + throughput +
+                ", writeFile='" + writeFile + '\'' +
+                ", readFile='" + readFile + '\'' +
+                ", startTime=" + startTime +
+                ", enableConnectionPooling=" + enableConnectionPooling +
+                ", writeWatermarkPeriodMillis=" + writeWatermarkPeriodMillis +
+                ", readWatermarkPeriodMillis=" + readWatermarkPeriodMillis;
+        }
     }
 }


### PR DESCRIPTION
**Change log description**
Logs the parameters being used by the test before it starts

**Purpose of the change**
Fixes #94 

**What the code does**
Before the test starts the parameters being used by the test are logged, i.e. 
```
>./pravega-benchmark -controller tcp://localhost:9090 -consumers 1 -scope dave -stream dave5  -segments 5 -time 5
2020-01-17 10:24:41:836 +0000 [main] INFO io.pravega.perf.PravegaPerfTest - Test Parameters: streamName='dave5', rdGrpName='dave5RdGrp', scopeName='dave', recreate=false, writeAndRead=false, producerCount=0, consumerCount=1, segmentCount=5, segmentScaleKBps=0, segmentScaleEventsPerSecond=0, scaleFactor=2, events=0, eventsPerSec=0, eventsPerProducer=0, eventsPerConsumer=0, EventsPerFlush=2147483647, transactionPerCommit=0, runtimeSec=5, throughput=-1.0, writeFile='null', readFile='null', startTime=1579256681824, enableConnectionPooling=true, writeWatermarkPeriodMillis=-1, readWatermarkPeriodMillis=-1
2020-01-17 10:24:42:106 +0000 [main] INFO io.pravega.client.stream.impl.ControllerImpl - Controller client connecting to server at localhost:9090
2020-01-17 10:24:42:109 +0000 [main] INFO io.pravega.client.stream.impl.ControllerImpl - Controller client connecting to server at localhost:9090
2020-01-17 10:24:42:116 +0000 [main] WARN io.pravega.client.netty.impl.ConnectionPoolImpl - Epoll not available. Falling back on NIO.

```
The change is very simple and I opted for using the `toString()` in order to quickly retrieve the parameters.  This means in future it should also be easy to keep it up to date when new parameters are added.

Signed-off-by: David Maddison <david.maddison@dell.com>