### PR TITLE
Issue 105: Fix TLS connection config error

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,12 @@ JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dpravega.client.auth.token=YWRtaW46MTEx
 export JAVA_TOOL_OPTIONS
 ```
 
-Moreover, TLS host name verification is turned off by default to make it easier to run this tool. To enable hostname
+Note:
+* The token used in the example above is for `Basic` authentication, which is handled by the Password Auth
+Handler. The token's value equals Base64 encoded value of string `{username}:{password}`. The value shown in the example
+above is Base64 encoded value of string `admin:1111_aaaa`. If you are using another authentication method supported
+by a custom Pravega Auth Handler, generate a corresponding token, and specify it instead.
+* Moreover, TLS host name verification is turned off by default to make it easier to run this tool. To enable hostname
 verification, specify `-validateCertHostName true` option when executing it.
 
 ## Running in Docker

--- a/README.md
+++ b/README.md
@@ -246,11 +246,12 @@ export JAVA_TOOL_OPTIONS
 ```
 
 Note:
-* The token used in the example above is for `Basic` authentication, which is handled by the Password Auth
-Handler. The token's value equals Base64 encoded value of string `{username}:{password}`. The value shown in the example
-above is Base64 encoded value of string `admin:1111_aaaa`. If you are using another authentication method supported
-by a custom Pravega Auth Handler, generate a corresponding token, and specify it instead.
-* Moreover, TLS host name verification is turned off by default to make it easier to run this tool. To enable hostname
+* The specified token `YWRtaW46MTExMV9hYWFh` shown in the example above equals Base64 encoded value of credentials
+in `{username}:{password}` format supported by the specified authentication method `Basic`. The specified token is
+Base64 encoded value of string `admin:1111_aaaa`, represent the admin account available in the Password Auth Handler
+database. If you are using another authentication method supported by a custom Pravega Auth Handler, generate a
+corresponding token, and specify the token and method here instead.
+* TLS host name verification is turned off by default to make it easier to run this tool. To enable hostname
 verification, specify `-validateCertHostName true` option when executing it.
 
 ## Running in Docker

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ for the client via the `JAVA_TOOL_OPTIONS` environment variable, before executin
 
 Below is an example:
 
-```
+```bash
 JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/path/to/client.truststore.jks"
 JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dpravega.client.auth.method=Basic"
 JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dpravega.client.auth.token=YWRtaW46MTExMV9hYWFh"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ usage: pravega-benchmark
                                      If >= 0 and using transactions,
                                      watermarks will be written on each
                                      commit.
+ -validateCertHostName               Whether to turn on host name verification
+                                     for TLS certificates
 ```
 ## Running Performance benchmarking
 
@@ -228,6 +230,23 @@ The `-throughput -1` specifies the writes tries to write the events at the maxim
 ### Recording the latencies to CSV files
 User can use the options `-writecsv  <file name>` to record the latencies of writers and `-readcsv <file name>` for readers.
 in case of End to End latency mode, if the user can supply only `-readcsv` to get the end to end latency in to the csv file.
+
+## Configuring Security Parameters
+
+To run against Security Enabled Pravega, you will need to specify TLS and authentication/authorization parameters
+for the client via the `JAVA_TOOL_OPTIONS` environment variable, before executing this tool.
+
+Below is an example:
+
+```
+JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/path/to/client.truststore.jks"
+JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dpravega.client.auth.method=Basic"
+JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dpravega.client.auth.token=YWRtaW46MTExMV9hYWFh"
+export JAVA_TOOL_OPTIONS
+```
+
+Moreover, TLS host name verification is turned off by default to make it easier to run this tool. To enable hostname
+verification, specify `-validateCertHostName true` option when executing it.
 
 ## Running in Docker
 

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -12,6 +12,7 @@ package io.pravega.perf;
 
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.netty.impl.ConnectionFactoryImpl;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ControllerImpl;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -98,6 +101,8 @@ public class PravegaPerfTest {
                 "If >0, watermarks will be read with a period of this many milliseconds.");
         options.addOption("reportingIntervalMillis", true, "period (in milliseconds) in which performance will be reported");
         options.addOption("createScope", true, "attempt to create Pravega scope(true by default)");
+        options.addOption("trustStoreLocation", true, "Location of the truststore to use when making TLS connections to server");
+        options.addOption("validateCertHostName", true, "Whether to turn on host name verification for TLS certificates");
 
         options.addOption("help", false, "Help message");
 
@@ -222,6 +227,8 @@ public class PravegaPerfTest {
         final long readWatermarkPeriodMillis;
         final int reportingInterval;
         final boolean createScope;
+        final String trustStoreLocation;
+        final boolean validateHostName;
 
         Test(long startTime, CommandLine commandline) throws IllegalArgumentException {
             this.startTime = startTime;
@@ -297,6 +304,14 @@ public class PravegaPerfTest {
             readWatermarkPeriodMillis = Long.parseLong(commandline.getOptionValue("readWatermarkPeriodMillis", "-1"));
 
             createScope = Boolean.parseBoolean(commandline.getOptionValue("createScope", "true"));
+
+            if (commandline.hasOption("trustStoreLocation")) {
+                trustStoreLocation = commandline.getOptionValue("trustStoreLocation");
+                log.debug("trustStoreLocation=" + trustStoreLocation);
+            } else {
+                trustStoreLocation = null;
+            }
+            validateHostName = Boolean.parseBoolean(commandline.getOptionValue("validateCertHostName", "false"));
 
             if (controllerUri == null) {
                 throw new IllegalArgumentException("Error: Must specify Controller IP address");
@@ -408,7 +423,6 @@ public class PravegaPerfTest {
                 return defaultValue;
             }
         }
-
     }
 
     static private class PravegaTest extends Test {
@@ -422,10 +436,19 @@ public class PravegaPerfTest {
             log.info("Test Parameters: {}", toString());
 
             final ScheduledExecutorService bgExecutor = Executors.newScheduledThreadPool(10);
+            ClientConfig.ClientConfigBuilder clientConfigBuilder = ClientConfig.builder().controllerURI(new URI(controllerUri));
+            if (controllerUri.startsWith("tls:") || controllerUri.startsWith("pravegas:")) {
+                if (trustStoreLocation != null) {
+                    if (!Files.exists(Paths.get(trustStoreLocation))) {
+                        throw new RuntimeException("Specified truststore file does not exist");
+                    }
+                    clientConfigBuilder.trustStore(trustStoreLocation);
+                }
+                clientConfigBuilder.validateHostName(false);
+            }
+            ClientConfig clientConfig = clientConfigBuilder.build();
             final ControllerImpl controller = new ControllerImpl(ControllerImplConfig.builder()
-                    .clientConfig(ClientConfig.builder().controllerURI(new URI(controllerUri)).build())
-                    .maxBackoffMillis(5000).build(),
-                    bgExecutor);
+                    .clientConfig(clientConfig).maxBackoffMillis(5000).build(), bgExecutor);
 
             streamHandle = new PravegaStreamHandler(scopeName, streamName, rdGrpName, controllerUri, segmentCount,
                     segmentScaleKBps, segmentScaleEventsPerSecond, scaleFactor, TIMEOUT, controller, bgExecutor, createScope);
@@ -439,12 +462,11 @@ public class PravegaPerfTest {
             }
 
             if (consumerCount > 0) {
-                readerGroup = streamHandle.createReaderGroup(!writeAndRead);
+                readerGroup = streamHandle.createReaderGroup(!writeAndRead, clientConfig);
             } else {
                 readerGroup = null;
             }
-
-            factory = new ClientFactoryImpl(scopeName, controller);
+            factory = new ClientFactoryImpl(scopeName, controller, new ConnectionFactoryImpl(clientConfig));
         }
 
         public List<WriterWorker> getProducers() {

--- a/src/main/java/io/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamHandler.java
@@ -148,10 +148,9 @@ public class PravegaStreamHandler {
         }
     }
 
-    ReaderGroup createReaderGroup(boolean reset) throws URISyntaxException {
+    ReaderGroup createReaderGroup(boolean reset, ClientConfig clientConfig) throws URISyntaxException {
         if (readerGroupManager == null) {
-            readerGroupManager = ReaderGroupManager.withScope(scope,
-                    ClientConfig.builder().controllerURI(new URI(controllerUri)).build());
+            readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
             rdGrpConfig = ReaderGroupConfig.builder()
                     .stream(Stream.of(scope, stream)).build();
         }


### PR DESCRIPTION
**Changelog description**  
Fix TLS connection config error.

When talking to TLS enabled server, while the client communicated with the Controller over `TLS`, it attempted to communicate with Segment Store services over `plaintext` channels, as opposed to the `TLS` channel it should have used. This led to Segment Store rejecting the connection and the exceptions shared in issue #105. This PR fixes that issue. 

**Purpose of the change**  
Resolves #105.

**What the code does**  
The code in this PR does the following: 
* Reuses the `ClientConfig` instance, so that the same configuration remains applicable for all client-server communications. 
* Introduces a new flag for specifying whether to validate server certificate hostname. 

**How to verify it**  
Here's how the verify it: 

1. Start the Pravega Standalone server with `TLS` and `auth` enabled. ([Steps](https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/securing-standalone-mode-cluster.md#enabling-ssltls-and-auth))

2. Run Pravega benchmark with `TLS` and `auth` params specified. 

   ```bash
   # Supply TLS and Auth Parameters via Environment Variables. 
   $ JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/path/to/client.truststore.jks"
   $ JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dpravega.client.auth.method=Basic"
   $ JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Dpravega.client.auth.token=YWRtaW46MTExMV9hYWFh"
   $ export JAVA_TOOL_OPTIONS

   # Execute a command using the Pravega Benchmark tool. 
   $ ./run/pravega-benchmark/bin/pravega-benchmark -scope test-scope -producers 1 \
       -controller "tls://localhost:9090" \
       -events 1 -time 5 -segments 1 -size 10 -stream test-stream
   ```
   The output should indicate a successful run, and should have no security exceptions.

   ```
   .... INFO io.pravega.perf.PerfStats - 5 records Writing ...
   ```
3. Try running another command that writes and reads, and check the output looks good. 
    ```bash
    $ ./run/pravega-benchmark/bin/pravega-benchmark \
     -controller "tls://localhost:9090"  \
     -scope test-scope2 -stream test-stream2  \
     -segments 1  \
     -producers 1 -consumers 1  \
     -size 100 \
     -throughput -1 \
     -time 30
    ```
