### PR TITLE
Issue 107: Adapt Pravega Benchmark to NoNetty changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ commonsCLIVersion=1.3.1
 commonsCSVVersion=1.5
 commonsMathVersion=3.6.1
 commonsIOVersion=1.3.2
-pravegaVersion=0.8.0-2508.30406cf-SNAPSHOT
+pravegaVersion=0.8.0-2599.8bd2bf4-SNAPSHOT
 pravegaKeycloakVersion=0.7.0
 slf4jSimpleVersion=1.7.14

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -12,11 +12,12 @@ package io.pravega.perf;
 
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.netty.impl.ConnectionFactoryImpl;
+import io.pravega.client.connection.impl.ConnectionFactory;
+import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
+import io.pravega.client.control.impl.ControllerImpl;
+import io.pravega.client.control.impl.ControllerImplConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
-import io.pravega.client.stream.impl.ControllerImpl;
-import io.pravega.client.stream.impl.ControllerImplConfig;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -29,8 +30,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -450,7 +449,7 @@ public class PravegaPerfTest {
             } else {
                 readerGroup = null;
             }
-            factory = new ClientFactoryImpl(scopeName, controller, new ConnectionFactoryImpl(clientConfig));
+            factory = new ClientFactoryImpl(scopeName, controller, new SocketConnectionFactoryImpl(clientConfig));
         }
 
         public List<WriterWorker> getProducers() {

--- a/src/main/java/io/pravega/perf/PravegaStreamHandler.java
+++ b/src/main/java/io/pravega/perf/PravegaStreamHandler.java
@@ -22,7 +22,7 @@ import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import io.pravega.client.stream.impl.ControllerImpl;
+import io.pravega.client.control.impl.ControllerImpl;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.ReaderGroupConfig;


### PR DESCRIPTION
**Change log description**
Adapted client classes to changes in Pravega client related to remove Netty from the write path.

**Purpose of the change**
Fixes #107.

**What the code does**
Fixes the package and class names that changes with PR https://github.com/pravega/pravega/pull/4873.

**How to verify it**
Tested with Pravega standalone and it works.
