### PR TITLE
Issue 110: Set connection pooling to false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Running Pravega benchmark tool locally:
 usage: pravega-benchmark
  -consumers <arg>                    Number of consumers
  -controller <arg>                   Controller URI
- -enableConnectionPooling <arg>      Set to false to disable connection
+ -enableConnectionPooling <arg>      Set to true to enable connection
                                      pooling
  -events <arg>                       Number of events/records if 'time'
                                      not specified;

--- a/src/main/java/io/pravega/perf/PravegaPerfTest.java
+++ b/src/main/java/io/pravega/perf/PravegaPerfTest.java
@@ -89,7 +89,7 @@ public class PravegaPerfTest {
         options.addOption("readcsv", true, "CSV file to record read latencies");
         options.addOption("writethroughputcsv", true, "CSV file to record write throughput");
         options.addOption("readthroughputcsv", true, "CSV file to record read throughput");
-        options.addOption("enableConnectionPooling", true, "Set to false to disable connection pooling");
+        options.addOption("enableConnectionPooling", false, "Set to true to enable connection pooling");
         options.addOption("writeWatermarkPeriodMillis", true,
                 "If -1 (default), watermarks will not be written.\n" +
                 "If 0 and not using transactions, watermarks will be written after every event.\n" +
@@ -295,7 +295,7 @@ public class PravegaPerfTest {
                 reportingInterval = DEFAULT_REPORTING_INTERVAL;
             }
 
-            enableConnectionPooling = Boolean.parseBoolean(commandline.getOptionValue("enableConnectionPooling", "true"));
+            enableConnectionPooling = Boolean.parseBoolean(commandline.getOptionValue("enableConnectionPooling", "false"));
 
             writeWatermarkPeriodMillis = Long.parseLong(commandline.getOptionValue("writeWatermarkPeriodMillis", "-1"));
             readWatermarkPeriodMillis = Long.parseLong(commandline.getOptionValue("readWatermarkPeriodMillis", "-1"));


### PR DESCRIPTION
**Change log description**
Sets connection pooling to false by default.

**Purpose of the change**
Fixes #110. 

**What the code does**
Makes the `enableConnectionPooling` variable to be `false` by default.

**How to verify it**
Executed `gradlew installDist` and it builds correctly. Also, executed the following command and observing that `enableConnectionPooling` is false when no input is set:
```
λ bash bin\pravega-benchmark -controller tcp://localhost:9090 -size 100 -segments 1 -stream test -time 10 -events 100 -producers 1
2020-08-17 16:05:59:876 +0200 [main] INFO io.pravega.perf.PravegaPerfTest - Test Parameters: streamName='test', rdGrpName='testRdGrp', scopeName='Scope', recreate=false, writeAndRead=false, producerCount=1, consumerCount=0, segmentCount=1, segmentScaleKBps=0, segmentScaleEventsPerSecond=0, scaleFactor=2, events=100, eventsPerSec=100, eventsPerProducer=100, eventsPerConsumer=0, EventsPerFlush=2147483647, transactionPerCommit=0, runtimeSec=10, throughput=-1.0, writeFile='null', readFile='null', startTime=1597673159850, enableConnectionPooling=false, writeWatermarkPeriodMillis=-1, readWatermarkPeriodMillis=-1
``` 


Signed-off-by: Raúl Gracia <raul.gracia@emc.com>