### PR TITLE
Issue 123: Update Pravega artifacts in master branch to 0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,11 @@ buildscript {
         jcenter()
         mavenCentral()
         maven {
-            url "https://oss.jfrog.org/jfrog-dependencies"
+            url "https://maven.pkg.github.com/pravega/pravega"
+            credentials {
+                username = "pravega-public"
+                password = "\u0067\u0068\u0070\u005F\u0048\u0034\u0046\u0079\u0047\u005A\u0031\u006B\u0056\u0030\u0051\u0070\u006B\u0079\u0058\u006D\u0035\u0063\u0034\u0055\u0033\u006E\u0032\u0065\u0078\u0039\u0032\u0046\u006E\u0071\u0033\u0053\u0046\u0076\u005A\u0049"
+            }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ commonsCLIVersion=1.3.1
 commonsCSVVersion=1.5
 commonsMathVersion=3.6.1
 commonsIOVersion=1.3.2
-pravegaVersion=0.10.1
+pravegaVersion=0.11.0-3038.fc1f5c3-SNAPSHOT
 pravegaKeycloakVersion=0.10.1
 slf4jSimpleVersion=1.7.14


### PR DESCRIPTION
**Change log description**
Upgraded Pravega artifact to latest Pravega 0.11 snapshot version.

**Purpose of the change**
Fixes https://github.com/pravega/pravega-benchmark/issues/123.

**What the code does**
Upgrades the artifact version for Pravega to the latest 0.11 snapshot.
Also, added Git Packages as a repo to download snapshot dependencies. 

**How to verify it**
Build must pass.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>
